### PR TITLE
Fix a few glitches in the ocaml codegen

### DIFF
--- a/serde-generate/tests/ocaml_generation.rs
+++ b/serde-generate/tests/ocaml_generation.rs
@@ -143,10 +143,10 @@ fn test_that_ocaml_code_compiles_with_custom_code() {
     let custom_code = vec![(
         vec!["testing".to_string(), "SerdeData".to_string()],
         r#"let serde_data_to_string = function
-  | PrimitiveTypes _ -> "primitive types"
-  | OtherTypes _ -> "other types"
-  | UnitVariant -> "unit variant"
-  | NewTypeVariant _ -> "new type variant"
+  | SerdeData_PrimitiveTypes _ -> "primitive types"
+  | SerdeData_OtherTypes _ -> "other types"
+  | SerdeData_UnitVariant -> "unit variant"
+  | SerdeData_NewTypeVariant _ -> "new type variant"
   | _ -> "etc""#
             .to_string(),
     )]

--- a/serde-generate/tests/ocaml_runtime.rs
+++ b/serde-generate/tests/ocaml_runtime.rs
@@ -98,26 +98,26 @@ fn test_ocaml_runtime_on_simple_data(runtime: Runtime) {
     writeln!(
         exe,
         r#"
-open Serde 
+open Serde
 open Stdint
 
 exception Unexpected_success
 
-let () = 
+let () =
   let input = Bytes.of_string {0} in
   let value = Deserialize.apply Testing.test_de input in
   let a = List.map Uint32.of_int [4; 6] in
   let b = -3L, Uint64.of_int 5 in
-  let c = Testing.C {{ x = Uint8.of_int 7 }} in
+  let c = Testing.Choice_C {{ x = Uint8.of_int 7 }} in
   let value2 = {{Testing.a; b; c}} in
   assert (value = value2);
   let output = Serialize.apply Testing.test_ser value2 in
   assert (input = output);
   let input2 = Bytes.of_string ({0} ^ "\001") in
-  try 
+  try
     let _ = Deserialize.apply Testing.test_de input2 in
     raise Unexpected_success
-  with 
+  with
   | Unexpected_success -> assert false
   | _ -> ()
 "#,


### PR DESCRIPTION
## Summary

* Add missing `to_caml_case()`
* Also test if field names are Ocaml keywords
* Prefix enum variants with the name of the enum (this is a bit sad in Ocaml but hard to avoid because Rust works like this)

## Test Plan

CI

```
curl https://raw.githubusercontent.com/aptos-labs/aptos-core/master/testsuite/generate-format/tests/staged/aptos.yaml > aptos.yaml

rm -rf test

cargo run --bin serdegen -- --language ocaml --with-runtimes serde bcs --target-source-dir test -- aptos.yaml

(cd test && dune build)
```