### PR TITLE
[swift] Write enum variants as camelCase

### DIFF
--- a/serde-generate/src/common.rs
+++ b/serde-generate/src/common.rs
@@ -42,10 +42,18 @@ pub(crate) fn mangle_type(format: &Format) -> String {
     }
 }
 
-pub(crate) fn capitalize(s: &str) -> String {
+pub(crate) fn uppercase_first_letter(s: &str) -> String {
     let mut c = s.chars();
     match c.next() {
         None => String::new(),
         Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
+}
+
+pub(crate) fn lowercase_first_letter(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_lowercase().collect::<String>() + c.as_str(),
     }
 }

--- a/serde-generate/src/ocaml.rs
+++ b/serde-generate/src/ocaml.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
-    common::capitalize,
+    common::uppercase_first_letter,
     indent::{IndentConfig, IndentedWriter},
     CodeGeneratorConfig, Encoding,
 };
@@ -119,7 +119,7 @@ where
     fn output_preamble(&mut self) -> Result<()> {
         for namespace in self.generator.libraries.iter() {
             if !namespace.is_empty() {
-                writeln!(self.out, "open {}", capitalize(namespace))?
+                writeln!(self.out, "open {}", uppercase_first_letter(namespace))?
             }
         }
         Ok(())

--- a/serde-generate/src/swift.rs
+++ b/serde-generate/src/swift.rs
@@ -469,6 +469,7 @@ return obj
     fn output_variant(&mut self, name: &str, variant: &VariantFormat) -> Result<()> {
         use VariantFormat::*;
         self.output_comment(name)?;
+        let name = common::lowercase_first_letter(name);
         match variant {
             Unit => {
                 writeln!(self.out, "case {}", name)?;
@@ -683,13 +684,14 @@ public static func {1}Deserialize(input: [UInt8]) throws -> {0} {{
             writeln!(self.out, "switch self {{")?;
             for (index, variant) in variants {
                 let fields = Self::variant_fields(&variant.value);
+                let formatted_variant_name = common::lowercase_first_letter(&variant.name);
                 if fields.is_empty() {
-                    writeln!(self.out, "case .{}:", variant.name)?;
+                    writeln!(self.out, "case .{}:", formatted_variant_name)?;
                 } else {
                     writeln!(
                         self.out,
                         "case .{}({}):",
-                        variant.name,
+                        formatted_variant_name,
                         fields
                             .iter()
                             .map(|f| format!("let {}", f.name))
@@ -739,10 +741,11 @@ switch index {{"#,
             for (index, variant) in variants {
                 writeln!(self.out, "case {}:", index)?;
                 self.out.indent();
+                let formatted_variant_name = common::lowercase_first_letter(&variant.name);
                 let fields = Self::variant_fields(&variant.value);
                 if fields.is_empty() {
                     writeln!(self.out, "try deserializer.decrease_container_depth()")?;
-                    writeln!(self.out, "return .{}", variant.name)?;
+                    writeln!(self.out, "return .{}", formatted_variant_name)?;
                     self.out.unindent();
                     continue;
                 }
@@ -767,7 +770,11 @@ switch index {{"#,
                         .collect::<Vec<_>>()
                         .join(", "),
                 };
-                writeln!(self.out, "return .{}({})", variant.name, init_values)?;
+                writeln!(
+                    self.out,
+                    "return .{}({})",
+                    formatted_variant_name, init_values
+                )?;
                 self.out.unindent();
             }
             writeln!(

--- a/serde-generate/tests/swift_runtime.rs
+++ b/serde-generate/tests/swift_runtime.rs
@@ -73,7 +73,7 @@ let value = try Test.{1}Deserialize(input: input)
 let value2 = Test.init(
     a: [4, 6],
     b: Tuple2.init(-3, 5),
-    c: Choice.C(x: 7)
+    c: Choice.c(x: 7)
 )
 assert(value == value2, "value != value2")
 


### PR DESCRIPTION
## Summary

Changes Swift enum variants to be expressed in camelCase, rather than Rust's UpperCamelCase. Addresses #10

## Test Plan

Swift tests are passing. It would be nice to have better testing in general on the generated code, as the coverage for a change like this is very small (as you can see in the test structure, it was a single character change), but I didn't want to try to write new tests unprompted, given how complicated the current testing setup appears to be.
