### PR TITLE
Modify the Dart enum generation to match other usage of c_style_enum

### DIFF
--- a/serde-generate/tests/dart_generation.rs
+++ b/serde-generate/tests/dart_generation.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use serde_generate::{dart, test_utils, CodeGeneratorConfig, Encoding, SourceInstaller};
+use std::fs::read_to_string;
 use std::{
     io::Result,
     path::{Path, PathBuf},
@@ -100,4 +101,24 @@ fn test_dart_code_compiles_with_class_enums() {
         .with_c_style_enums(false);
 
     generate_with_config(source_path, &config);
+}
+
+#[test]
+fn test_dart_code_compiles_class_enums_for_complex_enums() {
+    let source_path = tempdir().unwrap().path().join("dart_class_enum_project");
+
+    let config = CodeGeneratorConfig::new("example".to_string())
+        .with_encodings(vec![Encoding::Bcs, Encoding::Bincode])
+        // we enable native Dart enums to test that complex Rust enums will still produce Dart classes
+        .with_c_style_enums(true);
+
+    generate_with_config(source_path.clone(), &config);
+
+    let generated_c_style =
+        read_to_string(&source_path.join("lib/src/example/c_style_enum.dart")).unwrap();
+    let generated_class_style =
+        read_to_string(&source_path.join("lib/src/example/list.dart")).unwrap();
+
+    assert!(generated_c_style.contains("enum CStyleEnum {"));
+    assert!(generated_class_style.contains("abstract class List_ {"));
 }


### PR DESCRIPTION
## Summary

The C# implementation of enum generation looks at all variants of an enum and, if all are of type `Unit`, it then generates a native enum and otherwise generates a class. The current Dart implementation simply generates all classes if `c_style_enums = false` or all enums if `c_style_enums = true`.

This PR changes the Dart logic to match C# (the only other language that currently implements the `c_style_enums` config. dart.rs will now generate all classes if `c_style_enums = false` and if it is `true` it will generate native Dart enums unless the enum contains data, then it will generate a class.

## Test Plan

A test was added that verifies that when `c_style_enums` is enabled the generator will generate native Dart enums for the simple case but generate classes for data-containing enums.