### PR TITLE
add copyWith utility method to Dart classes

### DIFF
--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -813,13 +813,14 @@ return obj;
             self.out,
             "if (other.runtimeType != runtimeType) return false;"
         )?;
-        writeln!(self.out, "\nreturn other is {}", name)?;
+        write!(self.out, "\nreturn other is {}", name)?;
 
+        self.out.indent();
         for field in fields.iter() {
             let stmt = match &field.value {
                 Format::Seq(_) => {
                     format!(
-                        " listEquals({0}, other.{0})",
+                        "listEquals({0}, other.{0})",
                         self.quote_field(&field.name.to_mixed_case())
                     )
                 }
@@ -827,25 +828,25 @@ return obj;
                     content: _,
                     size: _,
                 } => format!(
-                    " listEquals({0}, other.{0})",
+                    "listEquals({0}, other.{0})",
                     self.quote_field(&field.name.to_mixed_case())
                 ),
                 Format::Map { .. } => {
                     format!(
-                        " mapEquals({0}, other.{0})",
+                        "mapEquals({0}, other.{0})",
                         self.quote_field(&field.name.to_mixed_case())
                     )
                 }
                 _ => format!(
-                    " {0} == other.{0}",
+                    "{0} == other.{0}",
                     self.quote_field(&field.name.to_mixed_case())
                 ),
             };
 
-            writeln!(self.out, "&& {}", stmt)?;
+            write!(self.out, "\n&& {}", stmt)?;
         }
-
-        write!(self.out, ";")?;
+        writeln!(self.out, ";")?;
+        self.out.unindent();
 
         self.out.unindent();
         writeln!(self.out, "}}")?;


### PR DESCRIPTION
## Summary

Add the common [`copyWith`](https://developer.school/tutorials/dart-flutter-what-does-copywith-do) utility method to generated Dart classes.

Uses [this method](https://stackoverflow.com/a/71591609) for allowing nullable properties to be set to `null`.

Additionally, I noticed some incorrect formatting of the `operator ==` method output while inspecting the code.
I added a fix for that, but I can split into a separate PR if that is preferable.

<details>
  <summary>Example other_types.dart output</summary>

```dart
  part of example_types;

@immutable
class OtherTypes {
  const OtherTypes({
    required this.fString,
    required this.fBytes,
    this.fOption,
    required this.fUnit,
    required this.fSeq,
    required this.fTuple,
    required this.fStringmap,
    required this.fIntset,
    required this.fNestedSeq,
  });

  OtherTypes.deserialize(BinaryDeserializer deserializer) :
    fString = deserializer.deserializeString(),
    fBytes = deserializer.deserializeBytes(),
    fOption = TraitHelpers.deserializeOptionStruct(deserializer),
    fUnit = deserializer.deserializeUnit(),
    fSeq = TraitHelpers.deserializeVectorStruct(deserializer),
    fTuple = TraitHelpers.deserializeTuple2U8U16(deserializer),
    fStringmap = TraitHelpers.deserializeMapStrToU32(deserializer),
    fIntset = TraitHelpers.deserializeMapU64ToUnit(deserializer),
    fNestedSeq = TraitHelpers.deserializeVectorVectorStruct(deserializer);

  static OtherTypes bincodeDeserialize(Uint8List input) {
    final deserializer = BincodeDeserializer(input);
    final value = OtherTypes.deserialize(deserializer);
    if (deserializer.offset < input.length) {
      throw Exception('Some input bytes were not read');
    }
    return value;
  }

  static OtherTypes bcsDeserialize(Uint8List input) {
    final deserializer = BcsDeserializer(input);
    final value = OtherTypes.deserialize(deserializer);
    if (deserializer.offset < input.length) {
      throw Exception('Some input bytes were not read');
    }
    return value;
  }

  final String fString;
  final Bytes fBytes;
  final Struct? fOption;
  final Unit fUnit;
  final List<Struct> fSeq;
  final Tuple2<int, int> fTuple;
  final Map<String, int> fStringmap;
  final Map<Uint64, Unit> fIntset;
  final List<List<Struct>> fNestedSeq;

  OtherTypes copyWith({
    String? fString,
    Bytes? fBytes,
    Struct? Function()? fOption,
    Unit? fUnit,
    List<Struct>? fSeq,
    Tuple2<int, int>? fTuple,
    Map<String, int>? fStringmap,
    Map<Uint64, Unit>? fIntset,
    List<List<Struct>>? fNestedSeq,
  }) {
    return OtherTypes(
      fString: fString ?? this.fString,
      fBytes: fBytes ?? this.fBytes,
      fOption: fOption == null ? this.fOption : fOption(),
      fUnit: fUnit ?? this.fUnit,
      fSeq: fSeq ?? this.fSeq,
      fTuple: fTuple ?? this.fTuple,
      fStringmap: fStringmap ?? this.fStringmap,
      fIntset: fIntset ?? this.fIntset,
      fNestedSeq: fNestedSeq ?? this.fNestedSeq,
    );
  }

  void serialize(BinarySerializer serializer) {
    serializer.serializeString(fString);
    serializer.serializeBytes(fBytes);
    TraitHelpers.serializeOptionStruct(fOption, serializer);
    serializer.serializeUnit(fUnit);
    TraitHelpers.serializeVectorStruct(fSeq, serializer);
    TraitHelpers.serializeTuple2U8U16(fTuple, serializer);
    TraitHelpers.serializeMapStrToU32(fStringmap, serializer);
    TraitHelpers.serializeMapU64ToUnit(fIntset, serializer);
    TraitHelpers.serializeVectorVectorStruct(fNestedSeq, serializer);
  }

  Uint8List bincodeSerialize() {
      final serializer = BincodeSerializer();
      serialize(serializer);
      return serializer.bytes;
  }

  Uint8List bcsSerialize() {
      final serializer = BcsSerializer();
      serialize(serializer);
      return serializer.bytes;
  }

  @override
  bool operator ==(Object other) {
    if (identical(this, other)) return true;
    if (other.runtimeType != runtimeType) return false;

    return other is OtherTypes
      && fString == other.fString
      && fBytes == other.fBytes
      && fOption == other.fOption
      && fUnit == other.fUnit
      && listEquals(fSeq, other.fSeq)
      && fTuple == other.fTuple
      && mapEquals(fStringmap, other.fStringmap)
      && mapEquals(fIntset, other.fIntset)
      && listEquals(fNestedSeq, other.fNestedSeq);
  }

  @override
  int get hashCode => Object.hash(
        fString,
        fBytes,
        fOption,
        fUnit,
        fSeq,
        fTuple,
        fStringmap,
        fIntset,
        fNestedSeq,
      );

  @override
  String toString() {
    String? fullString;

    assert(() {
      fullString = '$runtimeType('
        'fString: $fString, '
        'fBytes: $fBytes, '
        'fOption: $fOption, '
        'fUnit: $fUnit, '
        'fSeq: $fSeq, '
        'fTuple: $fTuple, '
        'fStringmap: $fStringmap, '
        'fIntset: $fIntset, '
        'fNestedSeq: $fNestedSeq'
        ')';
      return true;
    }());

    return fullString ?? 'OtherTypes';
  }
}
```
</details>

## Test Plan

I'm not sure if this needs separate tests outside of `analyze` still passing.
To verify my code worked, I logged out the path for one of the test projects and checked the output.
I'm not sure if there is a better way to inspect generated code.

cc: @jerel 