### PR TITLE
Make the handling of i128/u128 compatible with the Dart web platform

### DIFF
--- a/serde-generate/runtime/dart/serde/int_128.dart
+++ b/serde-generate/runtime/dart/serde/int_128.dart
@@ -14,7 +14,7 @@ class Int128 {
   factory Int128.fromBigInt(BigInt num) {
     final input = num.toSigned(128);
     final high = (input >> 64).toSigned(64);
-    final low = (input & BigInt.from(0xFFFFFFFFFFFFFFFF)).toSigned(64);
+    final low = (input & BigInt.parse('0xFFFFFFFFFFFFFFFF')).toSigned(64);
     return Int128(high, low);
   }
 

--- a/serde-generate/runtime/dart/serde/uint_128.dart
+++ b/serde-generate/runtime/dart/serde/uint_128.dart
@@ -16,7 +16,7 @@ class Uint128 {
   factory Uint128.fromBigInt(BigInt num) {
     final input = num.toUnsigned(128);
     final high = (input >> 64).toUnsigned(64);
-    final low = (input & BigInt.from(0xFFFFFFFFFFFFFFFF)).toUnsigned(64);
+    final low = (input & BigInt.parse('0xFFFFFFFFFFFFFFFF')).toUnsigned(64);
     return Uint128(high, low);
   }
 


### PR DESCRIPTION
## Summary

The 128 bit type implementations used a 64 bit number which isn't allowed on the Dart web platform (32 bits is the max supported). This switches from the BigInt `from` which takes a number to the `parse` function which uses a string to create a BigInt instance.

## Test Plan

`from` and `parse` are identical except that `parse` can throw an exception, in our usage it can never throw because the value is static.