### PR TITLE
[Dart] Remove unnecessary "Item" suffix from enum variant names

### DIFF
--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -1101,7 +1101,7 @@ switch (index) {{"#,
             for (index, variant) in variants {
                 writeln!(
                     self.out,
-                    "case {}: return {}{}Item.load(deserializer);",
+                    "case {}: return {}{}.load(deserializer);",
                     index,
                     self.quote_qualified_name(name).to_camel_case(),
                     self.quote_field(&variant.name),
@@ -1141,7 +1141,7 @@ switch (index) {{"#,
             self.output_variant(
                 base,
                 *index,
-                &format!("{}{}Item", base, &variant.name),
+                &format!("{}{}", base, &variant.name),
                 &variant.value,
             )?;
         }

--- a/serde-generate/tests/dart_runtime.rs
+++ b/serde-generate/tests/dart_runtime.rs
@@ -96,7 +96,7 @@ void main() {{"#
         Test expectedInstance = Test(
             a: [4, 6],
             b: Tuple2(-3, Uint64.parse('5')),
-            c: ChoiceCItem(x: 7),
+            c: ChoiceC(x: 7),
         );
 
         expect(deserializedInstance, equals(expectedInstance));


### PR DESCRIPTION
## Summary

My original implementation of Dart followed one of the other language's enum implementations in that it appended `Item` to the name of each variant. After using it for a while it turns out it's rather annoying and seems to be wholly unnecessary as the enum name is prepended to each variant when generating class based enums and this seems to avoid any chance of collision. Considering that Dart is still considered "under development" I figured it was a good time to walk this back.

For Rust enum:
```rust
enum Choice {
  A,
  B,
  C
}
```
Current output:
```dart
abstract class Choice {}

class ChoiceAItem extends Choice {}
class ChoiceBItem extends Choice {}
class ChoiceCItem extends Choice {} 
```

This PR's output:
```dart
abstract class Choice {}

class ChoiceA extends Choice {}
class ChoiceB extends Choice {}
class ChoiceC extends Choice {} 
```

## Test Plan

Uses existing test.
