### PR TITLE
set ci to use previous ubuntu version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: circleci/rust:bullseye
 
     steps:
@@ -50,7 +50,7 @@ jobs:
           cargo clippy --all-features --all-targets
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: circleci/rust:bullseye
 
     steps:


### PR DESCRIPTION
[`ubuntu-latest` was updated to 22.04](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/) and broke CI