### PR TITLE
Fix Dart list equality

### DIFF
--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -817,7 +817,15 @@ return obj;
 
         self.out.indent();
         for field in fields.iter() {
-            let stmt = match &field.value {
+            // because the Dart functions of listEquals and mapEquals accept nullable
+            // we only care about the data type and can discard the enclosing Format::Option
+            let value = if let Format::Option(value) = &field.value {
+                value
+            } else {
+                &field.value
+            };
+
+            let stmt = match value {
                 Format::Seq(_) => {
                     format!(
                         "listEquals({0}, other.{0})",

--- a/serde-generate/tests/dart_generation.rs
+++ b/serde-generate/tests/dart_generation.rs
@@ -55,7 +55,12 @@ fn test_dart_code_compiles() {
         .with_encodings(vec![Encoding::Bcs, Encoding::Bincode])
         .with_c_style_enums(true);
 
-    generate_with_config(source_path, &config);
+    generate_with_config(source_path.clone(), &config);
+
+    let other_types =
+        read_to_string(&source_path.join("lib/src/example/other_types.dart")).unwrap();
+
+    assert!(other_types.contains("listEquals(fOptSeq, other.fOptSeq)"));
 }
 
 #[test]

--- a/serde-generate/tests/test_utils.rs
+++ b/serde-generate/tests/test_utils.rs
@@ -679,6 +679,9 @@ OtherTypes:
     - f_seq:
         SEQ:
           TYPENAME: Struct
+    - f_opt_seq:
+        OPTION:
+          SEQ: I32
     - f_tuple:
         TUPLE:
           - U8

--- a/serde-generate/tests/test_utils.rs
+++ b/serde-generate/tests/test_utils.rs
@@ -83,6 +83,7 @@ pub struct OtherTypes {
     f_option: Option<Struct>,
     f_unit: (),
     f_seq: Vec<Struct>,
+    f_opt_seq: Option<Vec<i32>>,
     f_tuple: (u8, u16),
     f_stringmap: BTreeMap<String, u32>,
     f_intset: BTreeMap<u64, ()>, // Avoiding BTreeSet because Serde treats them as sequences.
@@ -182,6 +183,7 @@ pub fn get_sample_values(has_canonical_maps: bool, has_floats: bool) -> Vec<Serd
         f_option: Some(Struct { x: 2, y: 3 }),
         f_unit: (),
         f_seq: vec![Struct { x: 1, y: 3 }],
+        f_opt_seq: Some(vec![1]),
         f_tuple: (4, 5),
         f_stringmap: if has_canonical_maps {
             btreemap! {"foo".to_string() => 1, "bar".to_string() => 2}
@@ -201,6 +203,7 @@ pub fn get_sample_values(has_canonical_maps: bool, has_floats: bool) -> Vec<Serd
         f_option: None,
         f_unit: (),
         f_seq: Vec::new(),
+        f_opt_seq: None,
         f_tuple: (4, 5),
         f_stringmap: BTreeMap::new(),
         f_intset: if has_canonical_maps {
@@ -217,6 +220,7 @@ pub fn get_sample_values(has_canonical_maps: bool, has_floats: bool) -> Vec<Serd
         f_option: None,
         f_unit: (),
         f_seq: Vec::new(),
+        f_opt_seq: None,
         f_tuple: (4, 5),
         f_stringmap: BTreeMap::new(),
         f_intset: if has_canonical_maps {


### PR DESCRIPTION
## Summary

In the case of `Option<Vec<_>>` the generated Dart was not using `listEquals(field, other.field)` to check for equality like it does for `Vec<_>` because the match statement was checking `Option` and falling through to the default case of `field == other.field`.

## Test Plan

The test_utils.rs data structures didn't include a case where a vec was optional. This PR adds a field to demonstrate that case. This PR also includes test code which verifies that the generated Dart code is now correct.