### PR TITLE
Add support for Format::Any

### DIFF
--- a/serde-generate/src/common.rs
+++ b/serde-generate/src/common.rs
@@ -40,7 +40,9 @@ pub(crate) fn mangle_type(format: &Format) -> String {
         ),
         TupleArray { content, size } => format!("array{}_{}_array", size, mangle_type(content)),
         Variable(_) => panic!("unexpected value"),
-        Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+        Any => {
+            panic!("Types that require self-describing formats are not supported in serde-generate")
+        }
     }
 }
 

--- a/serde-generate/src/common.rs
+++ b/serde-generate/src/common.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use serde_reflection::Format;
+use serde_reflection::Format::Any;
 
 pub(crate) fn mangle_type(format: &Format) -> String {
     use Format::*;
@@ -39,6 +40,7 @@ pub(crate) fn mangle_type(format: &Format) -> String {
         ),
         TupleArray { content, size } => format!("array{}_{}_array", size, mangle_type(content)),
         Variable(_) => panic!("unexpected value"),
+        Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
     }
 }
 

--- a/serde-generate/src/common.rs
+++ b/serde-generate/src/common.rs
@@ -3,7 +3,6 @@
 
 use serde_reflection::Format;
 
-
 pub(crate) fn mangle_type(format: &Format) -> String {
     use Format::*;
     match format {

--- a/serde-generate/src/common.rs
+++ b/serde-generate/src/common.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use serde_reflection::Format;
-use serde_reflection::Format::Any;
+
 
 pub(crate) fn mangle_type(format: &Format) -> String {
     use Format::*;

--- a/serde-generate/src/cpp.rs
+++ b/serde-generate/src/cpp.rs
@@ -235,7 +235,9 @@ where
             ),
 
             Variable(_) => panic!("unexpected value"),
-            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+            Any => panic!(
+                "Types that require self-describing formats are not supported in serde-generate"
+            ),
         }
     }
 

--- a/serde-generate/src/cpp.rs
+++ b/serde-generate/src/cpp.rs
@@ -235,6 +235,7 @@ where
             ),
 
             Variable(_) => panic!("unexpected value"),
+            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
         }
     }
 

--- a/serde-generate/src/csharp.rs
+++ b/serde-generate/src/csharp.rs
@@ -15,6 +15,7 @@ use std::{
     io::{Result, Write},
     path::PathBuf,
 };
+use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in C#.
 pub struct CodeGenerator<'a> {
@@ -292,6 +293,7 @@ using System.Numerics;"
                 size: _size,
             } => format!("Serde.ValueArray<{}>", self.quote_type(content),),
             Variable(_) => panic!("unexpected value"),
+            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
         }
     }
 

--- a/serde-generate/src/csharp.rs
+++ b/serde-generate/src/csharp.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use heck::CamelCase;
 use include_dir::include_dir as include_directory;
+use serde_reflection::Format::Any;
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -15,7 +16,6 @@ use std::{
     io::{Result, Write},
     path::PathBuf,
 };
-use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in C#.
 pub struct CodeGenerator<'a> {
@@ -293,7 +293,9 @@ using System.Numerics;"
                 size: _size,
             } => format!("Serde.ValueArray<{}>", self.quote_type(content),),
             Variable(_) => panic!("unexpected value"),
-            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+            Any => panic!(
+                "Types that require self-describing formats are not supported in serde-generate"
+            ),
         }
     }
 

--- a/serde-generate/src/csharp.rs
+++ b/serde-generate/src/csharp.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use heck::CamelCase;
 use include_dir::include_dir as include_directory;
-use serde_reflection::Format::Any;
+
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},

--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -14,6 +14,7 @@ use std::{
     io::{Result, Write},
     path::{Path, PathBuf},
 };
+use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Dart.
 pub struct CodeGenerator<'a> {
@@ -274,6 +275,7 @@ where
             Tuple(formats) => format!("Tuple{}<{}>", formats.len(), self.quote_types(formats)),
             TupleArray { content, size: _ } => format!("List<{}>", self.quote_type(content)),
             Variable(_) => panic!("unexpected value"),
+            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
         }
     }
 

--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use heck::{CamelCase, MixedCase, SnakeCase};
 use include_dir::include_dir as include_directory;
-use serde_reflection::Format::Any;
+
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},

--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -8,13 +8,13 @@ use crate::{
 };
 use heck::{CamelCase, MixedCase, SnakeCase};
 use include_dir::include_dir as include_directory;
+use serde_reflection::Format::Any;
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},
     io::{Result, Write},
     path::{Path, PathBuf},
 };
-use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Dart.
 pub struct CodeGenerator<'a> {
@@ -275,7 +275,9 @@ where
             Tuple(formats) => format!("Tuple{}<{}>", formats.len(), self.quote_types(formats)),
             TupleArray { content, size: _ } => format!("List<{}>", self.quote_type(content)),
             Variable(_) => panic!("unexpected value"),
-            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+            Any => panic!(
+                "Types that require self-describing formats are not supported in serde-generate"
+            ),
         }
     }
 

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -13,6 +13,7 @@ use std::{
     io::{Result, Write},
     path::PathBuf,
 };
+use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Go.
 pub struct CodeGenerator<'a> {
@@ -238,6 +239,7 @@ where
             TupleArray { content, size } => format!("[{}]{}", size, self.quote_type(content)),
 
             Variable(_) => panic!("unexpected value"),
+            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
         }
     }
 

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -7,7 +7,7 @@ use crate::{
     CodeGeneratorConfig, Encoding,
 };
 use heck::CamelCase;
-use serde_reflection::Format::Any;
+
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -7,13 +7,13 @@ use crate::{
     CodeGeneratorConfig, Encoding,
 };
 use heck::CamelCase;
+use serde_reflection::Format::Any;
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},
     io::{Result, Write},
     path::PathBuf,
 };
-use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Go.
 pub struct CodeGenerator<'a> {
@@ -239,7 +239,9 @@ where
             TupleArray { content, size } => format!("[{}]{}", size, self.quote_type(content)),
 
             Variable(_) => panic!("unexpected value"),
-            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+            Any => panic!(
+                "Types that require self-describing formats are not supported in serde-generate"
+            ),
         }
     }
 

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -8,13 +8,13 @@ use crate::{
 };
 use heck::CamelCase;
 use include_dir::include_dir as include_directory;
+use serde_reflection::Format::Any;
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},
     io::{Result, Write},
     path::PathBuf,
 };
-use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Java.
 pub struct CodeGenerator<'a> {
@@ -228,7 +228,9 @@ where
                 self.quote_type(content)
             ),
             Variable(_) => panic!("unexpected value"),
-            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+            Any => panic!(
+                "Types that require self-describing formats are not supported in serde-generate"
+            ),
         }
     }
 

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -14,6 +14,7 @@ use std::{
     io::{Result, Write},
     path::PathBuf,
 };
+use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Java.
 pub struct CodeGenerator<'a> {
@@ -227,6 +228,7 @@ where
                 self.quote_type(content)
             ),
             Variable(_) => panic!("unexpected value"),
+            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
         }
     }
 

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use heck::CamelCase;
 use include_dir::include_dir as include_directory;
-use serde_reflection::Format::Any;
+
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},

--- a/serde-generate/src/ocaml.rs
+++ b/serde-generate/src/ocaml.rs
@@ -16,6 +16,7 @@ use std::{
     io::{Result, Write},
     path::PathBuf,
 };
+use serde_reflection::Format::Any;
 
 pub struct CodeGenerator<'a> {
     config: &'a CodeGeneratorConfig,
@@ -174,6 +175,7 @@ where
                 self.output_format(content, false)?;
                 write!(self.out, " array [@length {}])", size)?
             }
+            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
         }
         if is_struct {
             write!(self.out, " [@struct])")?

--- a/serde-generate/src/ocaml.rs
+++ b/serde-generate/src/ocaml.rs
@@ -10,13 +10,13 @@ use heck::CamelCase;
 use heck::SnakeCase;
 use include_dir::include_dir as include_directory;
 use phf::phf_set;
+use serde_reflection::Format::Any;
 use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
 use std::{
     collections::BTreeMap,
     io::{Result, Write},
     path::PathBuf,
 };
-use serde_reflection::Format::Any;
 
 pub struct CodeGenerator<'a> {
     config: &'a CodeGeneratorConfig,
@@ -175,7 +175,9 @@ where
                 self.output_format(content, false)?;
                 write!(self.out, " array [@length {}])", size)?
             }
-            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+            Any => panic!(
+                "Types that require self-describing formats are not supported in serde-generate"
+            ),
         }
         if is_struct {
             write!(self.out, " [@struct])")?

--- a/serde-generate/src/ocaml.rs
+++ b/serde-generate/src/ocaml.rs
@@ -10,7 +10,7 @@ use heck::CamelCase;
 use heck::SnakeCase;
 use include_dir::include_dir as include_directory;
 use phf::phf_set;
-use serde_reflection::Format::Any;
+
 use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
 use std::{
     collections::BTreeMap,

--- a/serde-generate/src/python3.rs
+++ b/serde-generate/src/python3.rs
@@ -5,7 +5,7 @@ use crate::{
     indent::{IndentConfig, IndentedWriter},
     CodeGeneratorConfig, Encoding,
 };
-use serde_reflection::Format::Any;
+
 use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},

--- a/serde-generate/src/python3.rs
+++ b/serde-generate/src/python3.rs
@@ -11,6 +11,7 @@ use std::{
     io::{Result, Write},
     path::PathBuf,
 };
+use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Python.
 pub struct CodeGenerator<'a> {
@@ -179,6 +180,7 @@ import typing
             ), // Sadly, there are no fixed-size arrays in python.
 
             Variable(_) => panic!("unexpected value"),
+            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
         }
     }
 

--- a/serde-generate/src/python3.rs
+++ b/serde-generate/src/python3.rs
@@ -5,13 +5,13 @@ use crate::{
     indent::{IndentConfig, IndentedWriter},
     CodeGeneratorConfig, Encoding,
 };
+use serde_reflection::Format::Any;
 use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},
     io::{Result, Write},
     path::PathBuf,
 };
-use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Python.
 pub struct CodeGenerator<'a> {
@@ -180,7 +180,9 @@ import typing
             ), // Sadly, there are no fixed-size arrays in python.
 
             Variable(_) => panic!("unexpected value"),
-            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+            Any => panic!(
+                "Types that require self-describing formats are not supported in serde-generate"
+            ),
         }
     }
 

--- a/serde-generate/src/rust.rs
+++ b/serde-generate/src/rust.rs
@@ -13,6 +13,7 @@ use std::{
     io::{Result, Write},
     path::PathBuf,
 };
+use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Rust.
 pub struct CodeGenerator<'a> {
@@ -257,6 +258,7 @@ where
             }
 
             Variable(_) => panic!("unexpected value"),
+            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
         }
     }
 

--- a/serde-generate/src/rust.rs
+++ b/serde-generate/src/rust.rs
@@ -6,7 +6,7 @@ use crate::{
     indent::{IndentConfig, IndentedWriter},
     CodeGeneratorConfig,
 };
-use serde_reflection::Format::Any;
+
 use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
 use std::{
     borrow::Cow,

--- a/serde-generate/src/rust.rs
+++ b/serde-generate/src/rust.rs
@@ -6,6 +6,7 @@ use crate::{
     indent::{IndentConfig, IndentedWriter},
     CodeGeneratorConfig,
 };
+use serde_reflection::Format::Any;
 use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
 use std::{
     borrow::Cow,
@@ -13,7 +14,6 @@ use std::{
     io::{Result, Write},
     path::PathBuf,
 };
-use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Rust.
 pub struct CodeGenerator<'a> {
@@ -258,7 +258,9 @@ where
             }
 
             Variable(_) => panic!("unexpected value"),
-            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+            Any => panic!(
+                "Types that require self-describing formats are not supported in serde-generate"
+            ),
         }
     }
 

--- a/serde-generate/src/swift.rs
+++ b/serde-generate/src/swift.rs
@@ -16,6 +16,7 @@ use std::{
     io::{Result, Write},
     path::PathBuf,
 };
+use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Swift.
 pub struct CodeGenerator<'a> {
@@ -165,6 +166,7 @@ where
             }
 
             Variable(_) => panic!("unexpected value"),
+            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
         }
     }
 

--- a/serde-generate/src/swift.rs
+++ b/serde-generate/src/swift.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use heck::CamelCase;
 use include_dir::include_dir as include_directory;
-use serde_reflection::Format::Any;
+
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},

--- a/serde-generate/src/swift.rs
+++ b/serde-generate/src/swift.rs
@@ -10,13 +10,13 @@ use crate::{
 };
 use heck::CamelCase;
 use include_dir::include_dir as include_directory;
+use serde_reflection::Format::Any;
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},
     io::{Result, Write},
     path::PathBuf,
 };
-use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in Swift.
 pub struct CodeGenerator<'a> {
@@ -166,7 +166,9 @@ where
             }
 
             Variable(_) => panic!("unexpected value"),
-            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+            Any => panic!(
+                "Types that require self-describing formats are not supported in serde-generate"
+            ),
         }
     }
 

--- a/serde-generate/src/typescript.rs
+++ b/serde-generate/src/typescript.rs
@@ -14,6 +14,7 @@ use std::{
     io::{Result, Write},
     path::PathBuf,
 };
+use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in TypeScript, powered by
 /// the Deno runtime.
@@ -157,6 +158,7 @@ import {{ Optional, Seq, Tuple, ListTuple, unit, bool, int8, int16, int32, int64
                 size: _size,
             } => format!("ListTuple<[{}]>", self.quote_type(content),),
             Variable(_) => panic!("unexpected value"),
+            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
         }
     }
 

--- a/serde-generate/src/typescript.rs
+++ b/serde-generate/src/typescript.rs
@@ -8,13 +8,13 @@ use crate::{
 };
 use heck::CamelCase;
 use include_dir::include_dir as include_directory;
+use serde_reflection::Format::Any;
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},
     io::{Result, Write},
     path::PathBuf,
 };
-use serde_reflection::Format::Any;
 
 /// Main configuration object for code-generation in TypeScript, powered by
 /// the Deno runtime.
@@ -158,7 +158,9 @@ import {{ Optional, Seq, Tuple, ListTuple, unit, bool, int8, int16, int32, int64
                 size: _size,
             } => format!("ListTuple<[{}]>", self.quote_type(content),),
             Variable(_) => panic!("unexpected value"),
-            Any => panic!("Types that require self-describing formats are not supported in serde-generate"),
+            Any => panic!(
+                "Types that require self-describing formats are not supported in serde-generate"
+            ),
         }
     }
 

--- a/serde-generate/src/typescript.rs
+++ b/serde-generate/src/typescript.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use heck::CamelCase;
 use include_dir::include_dir as include_directory;
-use serde_reflection::Format::Any;
+
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
     collections::{BTreeMap, HashMap},

--- a/serde-reflection/src/de.rs
+++ b/serde-reflection/src/de.rs
@@ -38,11 +38,12 @@ impl<'de, 'a> Deserializer<'de, 'a> {
 impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
     type Error = Error;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::NotSupported("deserialize_any"))
+        self.format.unify(Format::Any)?;
+        visitor.visit_str("deserialize_any is unsupported")
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>

--- a/serde-reflection/src/format.rs
+++ b/serde-reflection/src/format.rs
@@ -632,7 +632,8 @@ impl FormatHolder for Format {
                 }
             }
 
-            (Self::Unit, Self::Unit)
+            (Self::Any, Self::Any)
+            | (Self::Unit, Self::Unit)
             | (Self::Bool, Self::Bool)
             | (Self::I8, Self::I8)
             | (Self::I16, Self::I16)

--- a/serde-reflection/src/format.rs
+++ b/serde-reflection/src/format.rs
@@ -34,6 +34,9 @@ pub enum Format {
     /// The name of a container.
     TypeName(String),
 
+    // Format of self-describing dataformats like `serde_json::Value`
+    Any,
+
     // The formats of primitive types
     Unit,
     Bool,
@@ -505,7 +508,8 @@ impl FormatHolder for Format {
     fn visit<'a>(&'a self, f: &mut dyn FnMut(&'a Format) -> Result<()>) -> Result<()> {
         match self {
             Self::Variable(variable) => variable.visit(f)?,
-            Self::TypeName(_)
+            Self::Any
+            | Self::TypeName(_)
             | Self::Unit
             | Self::Bool
             | Self::I8
@@ -556,7 +560,8 @@ impl FormatHolder for Format {
                     .into_inner()
                     .expect("variable is known");
             }
-            Self::TypeName(_)
+            Self::Any
+            | Self::TypeName(_)
             | Self::Unit
             | Self::Bool
             | Self::I8

--- a/serde-reflection/tests/serde.rs
+++ b/serde-reflection/tests/serde.rs
@@ -503,7 +503,6 @@ fn test_default_value_for_primitive_types() {
     assert_eq!(value, "A borrowed str");
 }
 
-
 #[test]
 fn test_trace_value() {
     let mut tracer = Tracer::new(TracerConfig::default());
@@ -522,7 +521,7 @@ fn test_trace_value() {
             assert_eq!(fields.len(), 2);
             assert_eq!(fields[0].value, Format::Any);
             assert_eq!(fields[1].value, Format::U32);
-        },
+        }
         _ => panic!("should be a struct"),
     }
 }

--- a/serde-reflection/tests/serde.rs
+++ b/serde-reflection/tests/serde.rs
@@ -502,3 +502,27 @@ fn test_default_value_for_primitive_types() {
     assert_eq!(format, Format::Str);
     assert_eq!(value, "A borrowed str");
 }
+
+
+#[test]
+fn test_trace_value() {
+    let mut tracer = Tracer::new(TracerConfig::default());
+
+    #[derive(Serialize, Deserialize)]
+    struct Thing {
+        value: serde_json::Value,
+        other_field: u32,
+    }
+
+    tracer.trace_simple_type::<Thing>().unwrap();
+
+    let registry = tracer.registry().unwrap();
+    match registry.get("Thing").unwrap() {
+        ContainerFormat::Struct(fields) => {
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].value, Format::Any);
+            assert_eq!(fields[1].value, Format::U32);
+        },
+        _ => panic!("should be a struct"),
+    }
+}


### PR DESCRIPTION
## Summary

Hey there! I'm aware that the serde-reflection crate was developed in the context of serde-generate, but I'm using it for a different purpose, which is generating an XML schema for my serde-encoded types.

For this purpose I need to be able to detect types that require self-describing data structures, so I added a new variant to `Format` for this. I'm aware this is a breaking change and that you earlier rejected this proposal in https://github.com/zefchain/serde-reflection/issues/33, but I thought I'd try anyways, since otherwise I need to maintain my fork. 

Feel free to propose changes to my implementation or reject it outright if you feel this doesn't fit the crate.


