### PR TITLE
Support enum variants that have aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
+name = "erased-discriminant"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f74784b51403f16c5fa6dc667488389e629811329c1c6719c25874da2ba4f"
+dependencies = [
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,9 +442,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -489,12 +498,14 @@ name = "serde-reflection"
 version = "0.4.0"
 dependencies = [
  "bincode",
+ "erased-discriminant",
  "once_cell",
  "serde",
  "serde_bytes",
  "serde_json",
  "serde_yaml",
  "thiserror",
+ "typeid",
 ]
 
 [[package]]
@@ -508,13 +519,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -595,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -652,8 +663,14 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.85",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
 
 [[package]]
 name = "unicode-ident"

--- a/serde-reflection/Cargo.toml
+++ b/serde-reflection/Cargo.toml
@@ -17,9 +17,11 @@ exclude = [
 ]
 
 [dependencies]
-thiserror = "1.0.25"
-serde = { version = "1.0.126", features = ["derive"] }
+erased-discriminant = "1"
 once_cell = "1.7.2"
+serde = { version = "1.0.126", features = ["derive"] }
+thiserror = "1.0.25"
+typeid = "1"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/serde-reflection/src/de.rs
+++ b/serde-reflection/src/de.rs
@@ -406,6 +406,10 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
     where
         V: Visitor<'de>,
     {
+        if variants.is_empty() {
+            return Err(Error::NotSupported("deserialize_enum with 0 variants"));
+        }
+
         let enum_type_id = typeid::of::<V::Value>();
         self.format.unify(Format::TypeName(enum_name.into()))?;
         // Pre-update the registry.

--- a/serde-reflection/tests/serde.rs
+++ b/serde-reflection/tests/serde.rs
@@ -13,7 +13,10 @@ enum E {
     Unit,
     Newtype(u16),
     Tuple(u16, Option<bool>),
-    Struct { a: u32 },
+    Struct {
+        a: u32,
+    },
+    #[serde(alias = "NewTupleArray2")]
     NewTupleArray((u16, u16, u16)),
 }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/zefchain/serde-reflection/issues/52. Previously, in the case of an enum with aliases:

```rust
#[derive(Deserialize)]
enum Enum {
    A,
    #[serde(alias = "B1")]
    B,
}
```

serde-reflection would look at the list of expected variant names ("A", "B", "B1") and decide that it should expect to deserialize them using the same number of variant indices 0, 1, 2. This isn't correct because "B" and "B1" actually share the same index 1, and there does not exist any variant with index 2. Thus `tracer.trace_type::<Enum>` would fail with an error like _Failed to deserialize value: "invalid value: integer '2', expected variant index 0 &le; i < 2"_.

This PR improves `trace_type`'s deserializer to first try deserializing a variant using each of the supplied names ("A", "B", "B1"), record the enum discriminant of each resulting enum value, then deserializing again using sequential indices (0, 1, &hellip;) until it has found a result with the same discriminant as each of the named variants. From this it can see that both "A" and 0 deserialize to the same variant Enum::A, while all of "B" and "B1" and 1 deserialize to Enum::B.



## Test Plan

- `cd serde-reflection; cargo test`

- ```rust
  use serde_derive::Deserialize;
  use serde_reflection::{Samples, Tracer, TracerConfig};

  #[derive(Deserialize, Debug)]
  enum Enum {
      A,
      #[serde(alias = "B1")]
      B,
  }

  fn main() {
      let samples = Samples::new();
      let mut tracer = Tracer::new(TracerConfig::default());
      tracer.trace_type::<Enum>(&samples).unwrap();
      println!("{:#?}", tracer.registry().unwrap());
  }
  ```

  ```console
  {
      "Enum": Enum(
          {
              0: Named {
                  name: "A",
                  value: Unit,
              },
              1: Named {
                  name: "B",
                  value: Unit,
              },
          },
      ),
  }
  ```