### PR TITLE
Update Rust toolchain to the latest stable v1.83

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
         uses: swift-actions/setup-swift@bb83339d1e8577741bdc6c65ba551ce7dc0fb854
         with:
           # older swift versions are having gpg issues https://github.com/swift-actions/setup-swift/issues/520
-          swift-version: "5.7"
+          swift-version: "5.10.1"
 
       - name: Setup Additional Languages (ocaml)
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,11 +73,9 @@ jobs:
           echo '/github/home/.local/bin' >> $GITHUB_PATH
 
       - name: Setup Additional Languages (.Net)
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            2.1.x
-            3.1.x
+          dotnet-version: '3.1.x'
 
       - name: Setup Additional Languages (golang)
         uses: actions/setup-go@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
+  # https://stackoverflow.com/questions/59119904/process-terminated-couldnt-find-a-valid-icu-package-installed-on-the-system-in
+  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
 
 jobs:
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
           swift-version: "5.10.1"
 
       - name: Setup Additional Languages (ocaml)
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.0
           opam-disable-sandboxing: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "atty"
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bcs"
@@ -70,9 +70,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -97,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "erased-discriminant"
@@ -112,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys",
@@ -122,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
@@ -175,9 +181,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys",
 ]
@@ -218,21 +224,21 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "linked-hash-map"
@@ -254,15 +260,15 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "phf"
@@ -310,9 +316,12 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -346,18 +355,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -394,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -406,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -417,17 +426,17 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -442,9 +451,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.213"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
@@ -510,31 +519,32 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.213"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -606,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -617,12 +627,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
  "windows-sys",
 ]
@@ -648,22 +659,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -674,21 +685,21 @@ checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "vec_map"
@@ -698,9 +709,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -744,18 +755,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -769,51 +780,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yaml-rust"
@@ -822,4 +833,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.83.0"
 profile = "default"

--- a/serde-generate-bin/Cargo.toml
+++ b/serde-generate-bin/Cargo.toml
@@ -20,7 +20,7 @@ serde_yaml = "0.8.17"
 
 [dev-dependencies]
 tempfile = "3.2"
-serde = { version = "1.0.126", features = ["derive"] }
+serde = { version = "1.0.216", features = ["derive"] }
 serde_bytes = "0.11.5"
 
 [[bin]]

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -20,7 +20,7 @@ autotests = false
 [dependencies]
 heck = "0.3.2"
 include_dir = { version = "0.6.0", optional = true }
-serde = { version = "1.0.126", features = ["derive"] }
+serde = { version = "1.0.216", features = ["derive"] }
 textwrap = "0.13.4"
 phf = { version = "0.10", features = ["macros"], optional = true }
 serde-reflection = { path = "../serde-reflection", version = "0.5.0" }

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -19,7 +19,7 @@ The following programming languages are fully supported as target languages:
 * Python 3 (requires numpy >= 1.20.1)
 * Rust 2018
 * Go >= 1.14
-* C# (NetCoreApp >= 2.1)
+* C# (NetCoreApp >= 3.1)
 * Swift 5.3
 * OCaml
 * Dart >= 3

--- a/serde-generate/runtime/csharp/Serde.Tests/Serde.Tests.csproj
+++ b/serde-generate/runtime/csharp/Serde.Tests/Serde.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>

--- a/serde-generate/src/analyzer.rs
+++ b/serde-generate/src/analyzer.rs
@@ -23,9 +23,9 @@ fn get_dependencies<'a>(
 
 /// Build a map of dependencies between the entries of a `Registry`.
 /// * By definition, an entry named `x` depends on `y` iff the container format of `x` in the registry
-/// syntactically contains a reference to `y` (i.e. an expression `Format::TypeName(y)`).
+///   syntactically contains a reference to `y` (i.e. an expression `Format::TypeName(y)`).
 /// * Dependencies can play a role in code generation in some languages (e.g. Rust or C++) where inductive
-/// definitions may require explicit "boxing" (i.e. adding pointer indirections) to ensure finite object sizes.
+///   definitions may require explicit "boxing" (i.e. adding pointer indirections) to ensure finite object sizes.
 pub fn get_dependency_map(registry: &Registry) -> Result<BTreeMap<&str, BTreeSet<&str>>> {
     get_dependency_map_with_external_dependencies(registry, &BTreeSet::new())
 }

--- a/serde-generate/src/cpp.rs
+++ b/serde-generate/src/cpp.rs
@@ -103,7 +103,7 @@ impl<'a> CodeGenerator<'a> {
     }
 }
 
-impl<'a, T> CppEmitter<'a, T>
+impl<T> CppEmitter<'_, T>
 where
     T: std::io::Write,
 {

--- a/serde-generate/src/csharp.rs
+++ b/serde-generate/src/csharp.rs
@@ -158,7 +158,7 @@ impl<'a> CodeGenerator<'a> {
     }
 }
 
-impl<'a, T> CSharpEmitter<'a, T>
+impl<T> CSharpEmitter<'_, T>
 where
     T: Write,
 {

--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -187,7 +187,7 @@ import '../serde/serde.dart';"#,
     }
 }
 
-impl<'a, T> DartEmitter<'a, T>
+impl<T> DartEmitter<'_, T>
 where
     T: Write,
 {

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -102,7 +102,7 @@ impl<'a> CodeGenerator<'a> {
     }
 }
 
-impl<'a, T> GoEmitter<'a, T>
+impl<T> GoEmitter<'_, T>
 where
     T: Write,
 {

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -126,7 +126,7 @@ impl<'a> CodeGenerator<'a> {
     }
 }
 
-impl<'a, T> JavaEmitter<'a, T>
+impl<T> JavaEmitter<'_, T>
 where
     T: Write,
 {

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -16,7 +16,7 @@
 //! * Python 3 (requires numpy >= 1.20.1)
 //! * Rust 2018
 //! * Go >= 1.14
-//! * C# (NetCoreApp >= 2.1)
+//! * C# (NetCoreApp >= 3.1)
 //! * Swift 5.3
 //! * OCaml
 //! * Dart >= 3

--- a/serde-generate/src/ocaml.rs
+++ b/serde-generate/src/ocaml.rs
@@ -90,7 +90,7 @@ static KEYWORDS: phf::Set<&str> = phf_set! {
     "int32", "int64"
 };
 
-impl<'a, T> OCamlEmitter<'a, T>
+impl<T> OCamlEmitter<'_, T>
 where
     T: Write,
 {

--- a/serde-generate/src/python3.rs
+++ b/serde-generate/src/python3.rs
@@ -88,7 +88,7 @@ impl<'a> CodeGenerator<'a> {
     }
 }
 
-impl<'a, T> PythonEmitter<'a, T>
+impl<T> PythonEmitter<'_, T>
 where
     T: Write,
 {

--- a/serde-generate/src/rust.rs
+++ b/serde-generate/src/rust.rs
@@ -154,7 +154,7 @@ impl<'a> CodeGenerator<'a> {
     }
 }
 
-impl<'a, T> RustEmitter<'a, T>
+impl<T> RustEmitter<'_, T>
 where
     T: std::io::Write,
 {

--- a/serde-generate/src/swift.rs
+++ b/serde-generate/src/swift.rs
@@ -93,7 +93,7 @@ impl<'a> CodeGenerator<'a> {
     }
 }
 
-impl<'a, T> SwiftEmitter<'a, T>
+impl<T> SwiftEmitter<'_, T>
 where
     T: Write,
 {

--- a/serde-generate/src/typescript.rs
+++ b/serde-generate/src/typescript.rs
@@ -82,7 +82,7 @@ impl<'a> CodeGenerator<'a> {
     }
 }
 
-impl<'a, T> TypeScriptEmitter<'a, T>
+impl<T> TypeScriptEmitter<'_, T>
 where
     T: Write,
 {

--- a/serde-generate/tests/csharp_runtime.rs
+++ b/serde-generate/tests/csharp_runtime.rs
@@ -83,7 +83,7 @@ fn make_test_project(
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>

--- a/serde-name/Cargo.toml
+++ b/serde-name/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [dependencies]
 thiserror = "1.0.25"
-serde = { version = "1.0.126", features = ["derive"] }
+serde = { version = "1.0.216", features = ["derive"] }
 
 [dev-dependencies]
 serde-reflection = { path = "../serde-reflection", version = "0.5.0" }

--- a/serde-reflection/Cargo.toml
+++ b/serde-reflection/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 [dependencies]
 erased-discriminant = "1"
 once_cell = "1.7.2"
-serde = { version = "1.0.126", features = ["derive"] }
+serde = { version = "1.0.216", features = ["derive"] }
 thiserror = "1.0.25"
 typeid = "1"
 

--- a/serde-reflection/src/de.rs
+++ b/serde-reflection/src/de.rs
@@ -17,9 +17,9 @@ use std::collections::btree_map::{BTreeMap, Entry};
 
 /// Deserialize a single value.
 /// * The lifetime 'a is set by the deserialization call site and the
-/// `&'a mut` references used to return tracing results.
+///   `&'a mut` references used to return tracing results.
 /// * The lifetime 'de is fixed and the `&'de` reference meant to let us
-/// borrow values from previous serialization runs.
+///   borrow values from previous serialization runs.
 pub(crate) struct Deserializer<'de, 'a> {
     tracer: &'a mut Tracer,
     samples: &'de Samples,
@@ -40,7 +40,7 @@ impl<'de, 'a> Deserializer<'de, 'a> {
     }
 }
 
-impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
+impl<'de> de::Deserializer<'de> for Deserializer<'de, '_> {
     type Error = Error;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -670,7 +670,7 @@ impl<'de, 'a> EnumDeserializer<'de, 'a> {
     }
 }
 
-impl<'de, 'a> de::EnumAccess<'de> for EnumDeserializer<'de, 'a> {
+impl<'de> de::EnumAccess<'de> for EnumDeserializer<'de, '_> {
     type Error = Error;
     type Variant = Self;
 
@@ -686,7 +686,7 @@ impl<'de, 'a> de::EnumAccess<'de> for EnumDeserializer<'de, 'a> {
     }
 }
 
-impl<'de, 'a> de::VariantAccess<'de> for EnumDeserializer<'de, 'a> {
+impl<'de> de::VariantAccess<'de> for EnumDeserializer<'de, '_> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {

--- a/serde-reflection/src/format.rs
+++ b/serde-reflection/src/format.rs
@@ -129,7 +129,7 @@ pub trait FormatHolder {
 
     /// Mutably visit all the formats in `self` in a depth-first way.
     /// * Replace variables (if any) with their known values then apply the
-    /// visiting function `f`.
+    ///   visiting function `f`.
     /// * Return an error if any variable has still an unknown value (thus cannot be removed).
     fn visit_mut(&mut self, f: &mut dyn FnMut(&mut Format) -> Result<()>) -> Result<()>;
 
@@ -692,7 +692,7 @@ pub(crate) trait ContainerFormatEntry {
     fn unify(self, format: ContainerFormat) -> Result<()>;
 }
 
-impl<'a, K> ContainerFormatEntry for Entry<'a, K, ContainerFormat>
+impl<K> ContainerFormatEntry for Entry<'_, K, ContainerFormat>
 where
     K: std::cmp::Ord,
 {

--- a/serde-reflection/src/lib.rs
+++ b/serde-reflection/src/lib.rs
@@ -8,10 +8,10 @@
 //!
 //! Format descriptions are useful in several ways:
 //! * Stored under version control, formats can be tested to prevent unintended modifications
-//! of binary serialization formats (e.g. by changing variant order).
+//!   of binary serialization formats (e.g. by changing variant order).
 //! * Formats can be passed to [`serde-generate`](https://docs.rs/serde-generate)
-//! in order to generate class definitions and provide Serde-compatible binary
-//! serialization in other languages (C++, python, Java, etc).
+//!   in order to generate class definitions and provide Serde-compatible binary
+//!   serialization in other languages (C++, python, Java, etc).
 //!
 //! # Quick Start
 //!
@@ -79,41 +79,41 @@
 //! ## Supported features
 //!
 //! * Plain derived implementations obtained with `#[derive(Serialize, Deserialize)]` for
-//! Rust containers in the Serde [data model](https://serde.rs/data-model.html)
+//!   Rust containers in the Serde [data model](https://serde.rs/data-model.html)
 //!
 //! * Customized derived implementations using Serde attributes that are compatible with
-//! binary serialization formats, such as `#[serde(rename = "Name")]`.
+//!   binary serialization formats, such as `#[serde(rename = "Name")]`.
 //!
 //! * Hand-written implementations of `Deserialize` that are more restrictive than the
-//! derived ones, provided that `trace_value` is used during tracing to provide sample
-//! values for all such constrained types (see the detailed example below).
+//!   derived ones, provided that `trace_value` is used during tracing to provide sample
+//!   values for all such constrained types (see the detailed example below).
 //!
 //! * Mutually recursive types provided that the first variant of each enum is
-//! recursion-free. (For instance, `enum List { None, Some(Box<List>)}`.) Note that each
-//! enum must be traced separately with `trace_type` to discover all the variants.
+//!   recursion-free. (For instance, `enum List { None, Some(Box<List>)}`.) Note that each
+//!   enum must be traced separately with `trace_type` to discover all the variants.
 //!
 //! ## Unsupported idioms
 //!
 //! * Containers sharing the same base name (e.g. `Foo`) but from different modules. (Work
-//! around: use `#[serde(rename = ..)]`)
+//!   around: use `#[serde(rename = ..)]`)
 //!
 //! * Generic types instantiated multiple times in the same tracing session. (Work around:
-//! use the crate [`serde-name`](https://crates.io/crates/serde-name) and its adapters `SerializeNameAdapter` and `DeserializeNameAdapter`.)
+//!   use the crate [`serde-name`](https://crates.io/crates/serde-name) and its adapters `SerializeNameAdapter` and `DeserializeNameAdapter`.)
 //!
 //! * Attributes that are not compatible with binary formats (e.g. `#[serde(flatten)]`, `#[serde(tag = ..)]`)
 //!
 //! * Tracing type aliases. (E.g. `type Pair = (u32, u64)` will not create an entry "Pair".)
 //!
 //! * Mutually recursive types for which picking the first variant of each enum does not
-//! terminate. (Work around: re-order the variants. For instance `enum List {
-//! Some(Box<List>), None}` must be rewritten `enum List { None, Some(Box<List>)}`.)
+//!   terminate. (Work around: re-order the variants. For instance `enum List {
+//!   Some(Box<List>), None}` must be rewritten `enum List { None, Some(Box<List>)}`.)
 //!
 //! * Certain standard types such as `std::num::NonZeroU8` may not be tracked as a
-//! container and appear simply as their underlying primitive type (e.g. `u8`) in the
-//! formats. This loss of information makes it difficult to use `trace_value` to work
-//! around deserialization invariants (see example below). As a work around, you may
-//! override the default for the primitive type using `TracerConfig` (e.g. `let config =
-//! TracerConfig::default().default_u8_value(1);`).
+//!   container and appear simply as their underlying primitive type (e.g. `u8`) in the
+//!   formats. This loss of information makes it difficult to use `trace_value` to work
+//!   around deserialization invariants (see example below). As a work around, you may
+//!   override the default for the primitive type using `TracerConfig` (e.g. `let config =
+//!   TracerConfig::default().default_u8_value(1);`).
 //!
 //! ## Security CAVEAT
 //!
@@ -268,7 +268,7 @@
 //! * In enums, only the variants explicitly covered by user samples will be recorded.
 //!
 //! * Providing a `None` value or an empty vector `[]` within a sample may result in
-//! formats that are partially unknown.
+//!   formats that are partially unknown.
 //!
 //! ```rust
 //! # use serde_reflection::*;
@@ -340,12 +340,12 @@
 //! * while visiting an `Seq<T>` for the second time, we choose to return the empty sequence `[]`;
 //! * while visiting an `Map<K, V>` for the second time, we choose to return the empty map `{}`;
 //! * while visiting an `enum T` for the second time, we choose to return the first variant, i.e.
-//! a "base case" by assumption (1) above.
+//!   a "base case" by assumption (1) above.
 //!
 //! In addition to the cases above,
 //!
 //! * while visiting a container, if the container's name is mapped to a recorded value,
-//! we MAY decide to use it.
+//!   we MAY decide to use it.
 //!
 //! The default configuration `TracerConfig:default()` always picks the recorded value for a
 //! `NewTypeStruct` and never does in the other cases.

--- a/serde-reflection/src/ser.rs
+++ b/serde-reflection/src/ser.rs
@@ -279,7 +279,7 @@ pub struct SeqSerializer<'a> {
     values: Vec<Value>,
 }
 
-impl<'a> ser::SerializeSeq for SeqSerializer<'a> {
+impl ser::SerializeSeq for SeqSerializer<'_> {
     type Ok = (Format, Value);
     type Error = Error;
 
@@ -306,7 +306,7 @@ pub struct TupleSerializer<'a> {
     values: Vec<Value>,
 }
 
-impl<'a> ser::SerializeTuple for TupleSerializer<'a> {
+impl ser::SerializeTuple for TupleSerializer<'_> {
     type Ok = (Format, Value);
     type Error = Error;
 
@@ -334,7 +334,7 @@ pub struct TupleStructSerializer<'a> {
     values: Vec<Value>,
 }
 
-impl<'a> ser::SerializeTupleStruct for TupleStructSerializer<'a> {
+impl ser::SerializeTupleStruct for TupleStructSerializer<'_> {
     type Ok = (Format, Value);
     type Error = Error;
 
@@ -372,7 +372,7 @@ pub struct TupleVariantSerializer<'a> {
     values: Vec<Value>,
 }
 
-impl<'a> ser::SerializeTupleVariant for TupleVariantSerializer<'a> {
+impl ser::SerializeTupleVariant for TupleVariantSerializer<'_> {
     type Ok = (Format, Value);
     type Error = Error;
 
@@ -409,7 +409,7 @@ pub struct MapSerializer<'a> {
     values: Vec<Value>,
 }
 
-impl<'a> ser::SerializeMap for MapSerializer<'a> {
+impl ser::SerializeMap for MapSerializer<'_> {
     type Ok = (Format, Value);
     type Error = Error;
 
@@ -452,7 +452,7 @@ pub struct StructSerializer<'a> {
     values: Vec<Value>,
 }
 
-impl<'a> ser::SerializeStruct for StructSerializer<'a> {
+impl ser::SerializeStruct for StructSerializer<'_> {
     type Ok = (Format, Value);
     type Error = Error;
 
@@ -492,7 +492,7 @@ pub struct StructVariantSerializer<'a> {
     values: Vec<Value>,
 }
 
-impl<'a> ser::SerializeStructVariant for StructVariantSerializer<'a> {
+impl ser::SerializeStructVariant for StructVariantSerializer<'_> {
     type Ok = (Format, Value);
     type Error = Error;
 

--- a/serde-reflection/src/trace.rs
+++ b/serde-reflection/src/trace.rs
@@ -195,9 +195,9 @@ impl Tracer {
 
     /// Trace the serialization of a particular value.
     /// * Nested containers will be added to the tracing registry, indexed by
-    /// their (non-qualified) name.
+    ///   their (non-qualified) name.
     /// * Sampled Rust values will be inserted into `samples` to benefit future calls
-    /// to the `trace_type_*` methods.
+    ///   to the `trace_type_*` methods.
     pub fn trace_value<T>(&mut self, samples: &mut Samples, value: &T) -> Result<(Format, Value)>
     where
         T: ?Sized + Serialize,
@@ -210,12 +210,12 @@ impl Tracer {
 
     /// Trace a single deserialization of a particular type.
     /// * Nested containers will be added to the tracing registry, indexed by
-    /// their (non-qualified) name.
+    ///   their (non-qualified) name.
     /// * As a byproduct of deserialization, we also return a value of type `T`.
     /// * Tracing deserialization of a type may fail if this type or some dependencies
-    /// have implemented a custom deserializer that validates data. The solution is
-    /// to make sure that `samples` holds enough sampled Rust values to cover all the
-    /// custom types.
+    ///   have implemented a custom deserializer that validates data. The solution is
+    ///   to make sure that `samples` holds enough sampled Rust values to cover all the
+    ///   custom types.
     pub fn trace_type_once<'de, T>(&mut self, samples: &'de Samples) -> Result<(Format, T)>
     where
         T: Deserialize<'de>,
@@ -271,7 +271,7 @@ impl Tracer {
     /// Trace a type `T` that is simple enough that no samples of values are needed.
     /// * If `T` is an enum, the tracing iterates until all variants of `T` are covered.
     /// * Accumulate and return all the sampled values at the end.
-    /// This is merely a shortcut for `self.trace_type` with a fixed empty set of samples.
+    /// * This is merely a shortcut for `self.trace_type` with a fixed empty set of samples.
     pub fn trace_simple_type<'de, T>(&mut self) -> Result<(Format, Vec<T>)>
     where
         T: Deserialize<'de>,


### PR DESCRIPTION
## Summary

Update Rust toolchain to the latest stable v1.83

## Test Plan

CI