### PR TITLE
update CI for swift, ocaml, and C#

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
         uses: swift-actions/setup-swift@bb83339d1e8577741bdc6c65ba551ce7dc0fb854
         with:
           # older swift versions are having gpg issues https://github.com/swift-actions/setup-swift/issues/520
-          swift-version: "5.7"
+          swift-version: "5.10.1"
 
       - name: Setup Additional Languages (ocaml)
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
+  # https://stackoverflow.com/questions/59119904/process-terminated-couldnt-find-a-valid-icu-package-installed-on-the-system-in
+  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
 
 jobs:
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,11 +73,9 @@ jobs:
           echo '/github/home/.local/bin' >> $GITHUB_PATH
 
       - name: Setup Additional Languages (.Net)
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            2.1.x
-            3.1.x
+          dotnet-version: '6.0.x'
 
       - name: Setup Additional Languages (golang)
         uses: actions/setup-go@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
           swift-version: "5.10.1"
 
       - name: Setup Additional Languages (ocaml)
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.0
           opam-disable-sandboxing: true

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -19,7 +19,7 @@ The following programming languages are fully supported as target languages:
 * Python 3 (requires numpy >= 1.20.1)
 * Rust 2018
 * Go >= 1.14
-* C# (NetCoreApp >= 2.1)
+* C# (NetCoreApp >= 6.0)
 * Swift 5.3
 * OCaml
 * Dart >= 3

--- a/serde-generate/runtime/csharp/Serde.Tests/Serde.Tests.csproj
+++ b/serde-generate/runtime/csharp/Serde.Tests/Serde.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -16,7 +16,7 @@
 //! * Python 3 (requires numpy >= 1.20.1)
 //! * Rust 2018
 //! * Go >= 1.14
-//! * C# (NetCoreApp >= 2.1)
+//! * C# (NetCoreApp >= 6.0)
 //! * Swift 5.3
 //! * OCaml
 //! * Dart >= 3

--- a/serde-generate/tests/csharp_runtime.rs
+++ b/serde-generate/tests/csharp_runtime.rs
@@ -83,7 +83,7 @@ fn make_test_project(
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

* switch to swift 5.10
* switch to `ocaml/setup-ocaml@v3`
* switch to dotnet 6.0

## Test Plan

CI