### PR TITLE
Update rust-toolchain to version 1.81.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.81.0"
 profile = "default"

--- a/serde-generate/src/analyzer.rs
+++ b/serde-generate/src/analyzer.rs
@@ -23,9 +23,9 @@ fn get_dependencies<'a>(
 
 /// Build a map of dependencies between the entries of a `Registry`.
 /// * By definition, an entry named `x` depends on `y` iff the container format of `x` in the registry
-/// syntactically contains a reference to `y` (i.e. an expression `Format::TypeName(y)`).
+///   syntactically contains a reference to `y` (i.e. an expression `Format::TypeName(y)`).
 /// * Dependencies can play a role in code generation in some languages (e.g. Rust or C++) where inductive
-/// definitions may require explicit "boxing" (i.e. adding pointer indirections) to ensure finite object sizes.
+///   definitions may require explicit "boxing" (i.e. adding pointer indirections) to ensure finite object sizes.
 pub fn get_dependency_map(registry: &Registry) -> Result<BTreeMap<&str, BTreeSet<&str>>> {
     get_dependency_map_with_external_dependencies(registry, &BTreeSet::new())
 }

--- a/serde-reflection/src/de.rs
+++ b/serde-reflection/src/de.rs
@@ -17,9 +17,9 @@ use std::collections::btree_map::{BTreeMap, Entry};
 
 /// Deserialize a single value.
 /// * The lifetime 'a is set by the deserialization call site and the
-/// `&'a mut` references used to return tracing results.
+///   `&'a mut` references used to return tracing results.
 /// * The lifetime 'de is fixed and the `&'de` reference meant to let us
-/// borrow values from previous serialization runs.
+///   borrow values from previous serialization runs.
 pub(crate) struct Deserializer<'de, 'a> {
     tracer: &'a mut Tracer,
     samples: &'de Samples,

--- a/serde-reflection/src/format.rs
+++ b/serde-reflection/src/format.rs
@@ -129,7 +129,7 @@ pub trait FormatHolder {
 
     /// Mutably visit all the formats in `self` in a depth-first way.
     /// * Replace variables (if any) with their known values then apply the
-    /// visiting function `f`.
+    ///   visiting function `f`.
     /// * Return an error if any variable has still an unknown value (thus cannot be removed).
     fn visit_mut(&mut self, f: &mut dyn FnMut(&mut Format) -> Result<()>) -> Result<()>;
 

--- a/serde-reflection/src/lib.rs
+++ b/serde-reflection/src/lib.rs
@@ -8,10 +8,10 @@
 //!
 //! Format descriptions are useful in several ways:
 //! * Stored under version control, formats can be tested to prevent unintended modifications
-//! of binary serialization formats (e.g. by changing variant order).
+//!   of binary serialization formats (e.g. by changing variant order).
 //! * Formats can be passed to [`serde-generate`](https://docs.rs/serde-generate)
-//! in order to generate class definitions and provide Serde-compatible binary
-//! serialization in other languages (C++, python, Java, etc).
+//!   in order to generate class definitions and provide Serde-compatible binary
+//!   serialization in other languages (C++, python, Java, etc).
 //!
 //! # Quick Start
 //!
@@ -79,41 +79,41 @@
 //! ## Supported features
 //!
 //! * Plain derived implementations obtained with `#[derive(Serialize, Deserialize)]` for
-//! Rust containers in the Serde [data model](https://serde.rs/data-model.html)
+//!   Rust containers in the Serde [data model](https://serde.rs/data-model.html)
 //!
 //! * Customized derived implementations using Serde attributes that are compatible with
-//! binary serialization formats, such as `#[serde(rename = "Name")]`.
+//!   binary serialization formats, such as `#[serde(rename = "Name")]`.
 //!
 //! * Hand-written implementations of `Deserialize` that are more restrictive than the
-//! derived ones, provided that `trace_value` is used during tracing to provide sample
-//! values for all such constrained types (see the detailed example below).
+//!   derived ones, provided that `trace_value` is used during tracing to provide sample
+//!   values for all such constrained types (see the detailed example below).
 //!
 //! * Mutually recursive types provided that the first variant of each enum is
-//! recursion-free. (For instance, `enum List { None, Some(Box<List>)}`.) Note that each
-//! enum must be traced separately with `trace_type` to discover all the variants.
+//!   recursion-free. (For instance, `enum List { None, Some(Box<List>)}`.) Note that each
+//!   enum must be traced separately with `trace_type` to discover all the variants.
 //!
 //! ## Unsupported idioms
 //!
 //! * Containers sharing the same base name (e.g. `Foo`) but from different modules. (Work
-//! around: use `#[serde(rename = ..)]`)
+//!   around: use `#[serde(rename = ..)]`)
 //!
 //! * Generic types instantiated multiple times in the same tracing session. (Work around:
-//! use the crate [`serde-name`](https://crates.io/crates/serde-name) and its adapters `SerializeNameAdapter` and `DeserializeNameAdapter`.)
+//!   use the crate [`serde-name`](https://crates.io/crates/serde-name) and its adapters `SerializeNameAdapter` and `DeserializeNameAdapter`.)
 //!
 //! * Attributes that are not compatible with binary formats (e.g. `#[serde(flatten)]`, `#[serde(tag = ..)]`)
 //!
 //! * Tracing type aliases. (E.g. `type Pair = (u32, u64)` will not create an entry "Pair".)
 //!
 //! * Mutually recursive types for which picking the first variant of each enum does not
-//! terminate. (Work around: re-order the variants. For instance `enum List {
-//! Some(Box<List>), None}` must be rewritten `enum List { None, Some(Box<List>)}`.)
+//!   terminate. (Work around: re-order the variants. For instance `enum List {
+//!   Some(Box<List>), None}` must be rewritten `enum List { None, Some(Box<List>)}`.)
 //!
 //! * Certain standard types such as `std::num::NonZeroU8` may not be tracked as a
-//! container and appear simply as their underlying primitive type (e.g. `u8`) in the
-//! formats. This loss of information makes it difficult to use `trace_value` to work
-//! around deserialization invariants (see example below). As a work around, you may
-//! override the default for the primitive type using `TracerConfig` (e.g. `let config =
-//! TracerConfig::default().default_u8_value(1);`).
+//!   container and appear simply as their underlying primitive type (e.g. `u8`) in the
+//!   formats. This loss of information makes it difficult to use `trace_value` to work
+//!   around deserialization invariants (see example below). As a work around, you may
+//!   override the default for the primitive type using `TracerConfig` (e.g. `let config =
+//!   TracerConfig::default().default_u8_value(1);`).
 //!
 //! ## Security CAVEAT
 //!
@@ -268,7 +268,7 @@
 //! * In enums, only the variants explicitly covered by user samples will be recorded.
 //!
 //! * Providing a `None` value or an empty vector `[]` within a sample may result in
-//! formats that are partially unknown.
+//!   formats that are partially unknown.
 //!
 //! ```rust
 //! # use serde_reflection::*;
@@ -340,12 +340,12 @@
 //! * while visiting an `Seq<T>` for the second time, we choose to return the empty sequence `[]`;
 //! * while visiting an `Map<K, V>` for the second time, we choose to return the empty map `{}`;
 //! * while visiting an `enum T` for the second time, we choose to return the first variant, i.e.
-//! a "base case" by assumption (1) above.
+//!   a "base case" by assumption (1) above.
 //!
 //! In addition to the cases above,
 //!
 //! * while visiting a container, if the container's name is mapped to a recorded value,
-//! we MAY decide to use it.
+//!   we MAY decide to use it.
 //!
 //! The default configuration `TracerConfig:default()` always picks the recorded value for a
 //! `NewTypeStruct` and never does in the other cases.

--- a/serde-reflection/src/trace.rs
+++ b/serde-reflection/src/trace.rs
@@ -195,9 +195,9 @@ impl Tracer {
 
     /// Trace the serialization of a particular value.
     /// * Nested containers will be added to the tracing registry, indexed by
-    /// their (non-qualified) name.
+    ///   their (non-qualified) name.
     /// * Sampled Rust values will be inserted into `samples` to benefit future calls
-    /// to the `trace_type_*` methods.
+    ///   to the `trace_type_*` methods.
     pub fn trace_value<T>(&mut self, samples: &mut Samples, value: &T) -> Result<(Format, Value)>
     where
         T: ?Sized + Serialize,
@@ -210,12 +210,12 @@ impl Tracer {
 
     /// Trace a single deserialization of a particular type.
     /// * Nested containers will be added to the tracing registry, indexed by
-    /// their (non-qualified) name.
+    ///   their (non-qualified) name.
     /// * As a byproduct of deserialization, we also return a value of type `T`.
     /// * Tracing deserialization of a type may fail if this type or some dependencies
-    /// have implemented a custom deserializer that validates data. The solution is
-    /// to make sure that `samples` holds enough sampled Rust values to cover all the
-    /// custom types.
+    ///   have implemented a custom deserializer that validates data. The solution is
+    ///   to make sure that `samples` holds enough sampled Rust values to cover all the
+    ///   custom types.
     pub fn trace_type_once<'de, T>(&mut self, samples: &'de Samples) -> Result<(Format, T)>
     where
         T: Deserialize<'de>,
@@ -271,7 +271,7 @@ impl Tracer {
     /// Trace a type `T` that is simple enough that no samples of values are needed.
     /// * If `T` is an enum, the tracing iterates until all variants of `T` are covered.
     /// * Accumulate and return all the sampled values at the end.
-    /// This is merely a shortcut for `self.trace_type` with a fixed empty set of samples.
+    ///   This is merely a shortcut for `self.trace_type` with a fixed empty set of samples.
     pub fn trace_simple_type<'de, T>(&mut self) -> Result<(Format, Vec<T>)>
     where
         T: Deserialize<'de>,


### PR DESCRIPTION
## Summary

The version of the compiler should be at least 1.81.0 for REVM which is used for testing solidity code.

## Test Plan

The CI is the basic testing framework.