### PR TITLE
Do not overwrite `pubspec.yaml` if it already exists

### DIFF
--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -79,7 +79,11 @@ impl<'a> CodeGenerator<'a> {
     }
 
     fn write_package(&self, install_dir: &Path) -> Result<()> {
-        let mut file = std::fs::File::create(install_dir.join("pubspec.yaml"))?;
+        let pubspec_path = install_dir.join("pubspec.yaml");
+        if pubspec_path.exists() {
+            return Ok(());
+        }
+        let mut file = std::fs::File::create(pubspec_path)?;
         let mut out = IndentedWriter::new(&mut file, IndentConfig::Space(2));
         writeln!(
             &mut out,


### PR DESCRIPTION
## Summary

Hi all,

First off, thanks for all the hard work you do maintaining this repository—it truly is a great work.

In this PR, I've updated the `CodeGenerator.output` method so that it ignores an existing `pubspec.yaml`, preventing it from being overwritten when using `serde-generate` for Dart code. I'm open to any modifications or suggestions, and I'll respond as quickly as possible to any feedback. This change is intended for use at [Rinf](https://github.com/cunarist/rinf).

Looking forward to your thoughts!

## Test Plan

Empty
