### PR TITLE
Make Dart linter happy

### DIFF
--- a/serde-generate/runtime/dart/bcs/bcs_deserializer.dart
+++ b/serde-generate/runtime/dart/bcs/bcs_deserializer.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of bcs;
+part of 'bcs.dart';
 
 // Maximum length allowed for sequences (vectors, bytes, strings) and maps.
 const maxSequenceLength = (1 << 31) - 1;

--- a/serde-generate/runtime/dart/bcs/bcs_serializer.dart
+++ b/serde-generate/runtime/dart/bcs/bcs_serializer.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of bcs;
+part of 'bcs.dart';
 
 class BcsSerializer extends BinarySerializer {
   BcsSerializer()

--- a/serde-generate/runtime/dart/bincode/bincode_deserializer.dart
+++ b/serde-generate/runtime/dart/bincode/bincode_deserializer.dart
@@ -8,7 +8,7 @@ const maxContainerDepth = (1 << 31) - 1;
 
 class BincodeDeserializer extends BinaryDeserializer {
   BincodeDeserializer(Uint8List input)
-    : super(input: input, containerDepthBudget: maxContainerDepth);
+      : super(input: input, containerDepthBudget: maxContainerDepth);
 
   @override
   int deserializeLength() {

--- a/serde-generate/runtime/dart/bincode/bincode_deserializer.dart
+++ b/serde-generate/runtime/dart/bincode/bincode_deserializer.dart
@@ -1,14 +1,14 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of bincode;
+part of 'bincode.dart';
 
 // Maximum number of nested structs and enum variants.
 const maxContainerDepth = (1 << 31) - 1;
 
 class BincodeDeserializer extends BinaryDeserializer {
   BincodeDeserializer(Uint8List input)
-      : super(input: input, containerDepthBudget: maxContainerDepth);
+    : super(input: input, containerDepthBudget: maxContainerDepth);
 
   @override
   int deserializeLength() {

--- a/serde-generate/runtime/dart/bincode/bincode_serializer.dart
+++ b/serde-generate/runtime/dart/bincode/bincode_serializer.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of bincode;
+part of 'bincode.dart';
 
 class BincodeSerializer extends BinarySerializer {
   BincodeSerializer()

--- a/serde-generate/runtime/dart/serde/binary_deserializer.dart
+++ b/serde-generate/runtime/dart/serde/binary_deserializer.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of serde;
+part of 'serde.dart';
 
 abstract class BinaryDeserializer {
   BinaryDeserializer({

--- a/serde-generate/runtime/dart/serde/binary_serializer.dart
+++ b/serde-generate/runtime/dart/serde/binary_serializer.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of serde;
+part of 'serde.dart';
 
 abstract class BinarySerializer {
   BinarySerializer({

--- a/serde-generate/runtime/dart/serde/bytes.dart
+++ b/serde-generate/runtime/dart/serde/bytes.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of serde;
+part of 'serde.dart';
 
 /**
  * Immutable wrapper class around byte[].

--- a/serde-generate/runtime/dart/serde/hash_utils.dart
+++ b/serde-generate/runtime/dart/serde/hash_utils.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of serde;
+part of 'serde.dart';
 
 const maxInt = 4294967296;
 

--- a/serde-generate/runtime/dart/serde/int_128.dart
+++ b/serde-generate/runtime/dart/serde/int_128.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of serde;
+part of 'serde.dart';
 
 @immutable
 class Int128 {

--- a/serde-generate/runtime/dart/serde/slice.dart
+++ b/serde-generate/runtime/dart/serde/slice.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of serde;
+part of 'serde.dart';
 
 @immutable
 class Slice {

--- a/serde-generate/runtime/dart/serde/uint_128.dart
+++ b/serde-generate/runtime/dart/serde/uint_128.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of serde;
+part of 'serde.dart';
 
 ///
 /// A Dart type to represent the Rust u128 type.

--- a/serde-generate/runtime/dart/serde/uint_64.dart
+++ b/serde-generate/runtime/dart/serde/uint_64.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of serde;
+part of 'serde.dart';
 
 ///
 /// A Dart type to represent the Rust u64 type.

--- a/serde-generate/runtime/dart/serde/unit.dart
+++ b/serde-generate/runtime/dart/serde/unit.dart
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-part of serde;
+part of 'serde.dart';
 
 @immutable
 class Unit {

--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -114,7 +114,8 @@ dependencies:
 
         writeln!(
             &mut emitter.out,
-            r#"library {}_types;
+            r#"// ignore_for_file: unused_import
+library {}_types;
 
 import 'dart:typed_data';
 import 'package:meta/meta.dart';
@@ -1192,7 +1193,7 @@ switch (index) {{"#,
     }
 }
 
-/// Installer for generated source files in Go.
+/// Installer for generated source files in Dart.
 pub struct Installer {
     install_dir: PathBuf,
 }

--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -195,7 +195,7 @@ where
     fn output_preamble(&mut self) -> Result<()> {
         writeln!(
             self.out,
-            "part of {}_types;",
+            "part of '{}.dart';",
             self.generator.config.module_name
         )?;
 


### PR DESCRIPTION
## Summary

When trying to use `serde-generate` in a real-life scenario, the Dart linter warned about specific rule violations. This PR addresses those warnings.

- `unused_import`
  ![image](https://github.com/user-attachments/assets/f8a9d769-32df-433a-9866-0341a1946f36)
  - [Dart docs](https://dart.dev/diagnostics/unused_import)
  - `package:meta` or `package:tuple` might be unused in some scenarios.
- `use_string_in_part_of_directives`
  ![image](https://github.com/user-attachments/assets/9f6daeff-2bab-41ba-9a74-e85f85bbf117)
  ![image](https://github.com/user-attachments/assets/31ae64f3-773d-4542-9e88-8bc001141877)
  - [Dart docs](https://dart.dev/diagnostics/use_string_in_part_of_directives)


## Test Plan

If the CI passes, everything should be fine.
