### PR TITLE
fix goland CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Additional Languages (golang)
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.15.0'
+          go-version: '~1.22.0'
 
       - name: Setup Additional Languages (deno)
         uses: denoland/setup-deno@v1

--- a/serde-generate/tests/golang_generation.rs
+++ b/serde-generate/tests/golang_generation.rs
@@ -79,6 +79,7 @@ fn test_that_golang_code_compiles_with_config_and_registry(
     let status = Command::new("go")
         .current_dir(dir.path())
         .arg("build")
+        .arg("-mod=mod")
         .arg(&source_path)
         .status()
         .unwrap();

--- a/serde-generate/tests/golang_runtime.rs
+++ b/serde-generate/tests/golang_runtime.rs
@@ -120,6 +120,7 @@ func main() {{
     let status = Command::new("go")
         .current_dir(dir.path())
         .arg("run")
+        .arg("-mod=mod")
         .arg(&source_path)
         .status()
         .unwrap();
@@ -251,6 +252,7 @@ func main() {{
     let status = Command::new("go")
         .current_dir(dir.path())
         .arg("run")
+        .arg("-mod=mod")
         .arg(source_path)
         .status()
         .unwrap();


### PR DESCRIPTION
## Summary

Fix CI for Golang after a change in the default behavior.

I tried calling `go mod tidy` but it complains about name collision in some cases so just reverting to the previous behavior.

However `-mod=mod` is not working well for golang 1.15 so I upgraded CI to 1.22.

See also https://stackoverflow.com/questions/66469396/go-module-is-found-and-replaced-but-not-required#comment117706021_66470269

## Test Plan

CI