### PR TITLE
Make Dart linter happy by adapting to its rules

### DIFF
--- a/serde-generate/runtime/dart/bcs/bcs_serializer.dart
+++ b/serde-generate/runtime/dart/bcs/bcs_serializer.dart
@@ -27,6 +27,7 @@ class BcsSerializer extends BinarySerializer {
     serializeUint32AsUleb128(value);
   }
 
+  @override
   void sortMapEntries(List<int> offsets) {
     if (offsets.isEmpty) {
       return;

--- a/serde-generate/runtime/dart/bincode/bincode_serializer.dart
+++ b/serde-generate/runtime/dart/bincode/bincode_serializer.dart
@@ -19,6 +19,7 @@ class BincodeSerializer extends BinarySerializer {
     serializeUint32(value);
   }
 
+  @override
   void sortMapEntries(List<int> offsets) {
     // Not required by the format.
   }

--- a/serde-generate/runtime/dart/serde/binary_deserializer.dart
+++ b/serde-generate/runtime/dart/serde/binary_deserializer.dart
@@ -27,7 +27,7 @@ abstract class BinaryDeserializer {
       return true;
     } else {
       throw Exception(
-        'Invalid boolean: expected 0 or 1, but got ${result}',
+        'Invalid boolean: expected 0 or 1, but got $result',
       );
     }
   }

--- a/serde-generate/runtime/dart/serde/binary_serializer.dart
+++ b/serde-generate/runtime/dart/serde/binary_serializer.dart
@@ -61,12 +61,12 @@ abstract class BinarySerializer {
 
   void serializeUint64(Uint64 val) {
     BigInt number = val.toBigInt();
-    final _byteMask = BigInt.from(0xFF);
+    final byteMask = BigInt.from(0xFF);
     int bytes = 8;
     var bdata = Uint8List(bytes);
     for (int i = 0; i < bytes; i++) {
       // little endian
-      bdata[i] = (number & _byteMask).toInt();
+      bdata[i] = (number & byteMask).toInt();
       number = number >> 8;
     }
 

--- a/serde-generate/runtime/dart/serde/bytes.dart
+++ b/serde-generate/runtime/dart/serde/bytes.dart
@@ -3,11 +3,8 @@
 
 part of 'serde.dart';
 
-/**
- * Immutable wrapper class around byte[].
- *
- * Enforces value-semantice for `equals` and `hashCode`.
- */
+/// Immutable wrapper class around byte[].
+/// Enforces value-semantice for `equals` and `hashCode`.
 @immutable
 class Bytes {
   const Bytes(this.content);

--- a/serde-generate/runtime/dart/serde/int_128.dart
+++ b/serde-generate/runtime/dart/serde/int_128.dart
@@ -5,7 +5,7 @@ part of 'serde.dart';
 
 @immutable
 class Int128 {
-  Int128(this.high, this.low);
+  const Int128(this.high, this.low);
 
   factory Int128.parse(String num, {int? radix}) {
     return Int128.fromBigInt(BigInt.parse(num, radix: radix));

--- a/serde-generate/runtime/dart/serde/uint_128.dart
+++ b/serde-generate/runtime/dart/serde/uint_128.dart
@@ -3,7 +3,6 @@
 
 part of 'serde.dart';
 
-///
 /// A Dart type to represent the Rust u128 type.
 @immutable
 class Uint128 {

--- a/serde-generate/runtime/dart/serde/uint_128.dart
+++ b/serde-generate/runtime/dart/serde/uint_128.dart
@@ -7,7 +7,7 @@ part of 'serde.dart';
 /// A Dart type to represent the Rust u128 type.
 @immutable
 class Uint128 {
-  Uint128(this.high, this.low);
+  const Uint128(this.high, this.low);
 
   factory Uint128.parse(String num, {int? radix}) {
     return Uint128.fromBigInt(BigInt.parse(num, radix: radix));

--- a/serde-generate/runtime/dart/serde/uint_64.dart
+++ b/serde-generate/runtime/dart/serde/uint_64.dart
@@ -7,7 +7,7 @@ part of 'serde.dart';
 /// A Dart type to represent the Rust u64 type.
 @immutable
 class Uint64 {
-  Uint64(this._high);
+  const Uint64(this._high);
 
   factory Uint64.parse(String num, {int? radix}) {
     return Uint64.fromBigInt(BigInt.parse(num, radix: radix));

--- a/serde-generate/runtime/dart/serde/uint_64.dart
+++ b/serde-generate/runtime/dart/serde/uint_64.dart
@@ -3,7 +3,6 @@
 
 part of 'serde.dart';
 
-///
 /// A Dart type to represent the Rust u64 type.
 @immutable
 class Uint64 {

--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -833,47 +833,46 @@ return obj;
         writeln!(self.out, "}}")?;
 
         // Hashing
-        if field_count > 0 {
-            write!(self.out, "\n@override")?;
+        write!(self.out, "\n@override")?;
+        if field_count == 0 {
+            writeln!(self.out, "\nint get hashCode => runtimeType.hashCode;")?;
+        } else if field_count == 1 {
+            writeln!(
+                self.out,
+                "\nint get hashCode => {}.hashCode;",
+                fields.first().unwrap().name.to_mixed_case()
+            )?;
+        } else {
+            let use_hash_all = field_count > 20;
 
-            if field_count == 1 {
+            if use_hash_all {
+                writeln!(self.out, "\nint get hashCode => Object.hashAll([")?;
+            } else {
+                writeln!(self.out, "\nint get hashCode => Object.hash(")?;
+            }
+
+            self.out.indent();
+            self.out.indent();
+            self.out.indent();
+
+            for field in fields {
                 writeln!(
                     self.out,
-                    "\nint get hashCode => {}.hashCode;",
-                    fields.first().unwrap().name.to_mixed_case()
+                    "{},",
+                    self.quote_field(&field.name.to_mixed_case())
                 )?;
-            } else {
-                let use_hash_all = field_count > 20;
-
-                if use_hash_all {
-                    writeln!(self.out, "\nint get hashCode => Object.hashAll([")?;
-                } else {
-                    writeln!(self.out, "\nint get hashCode => Object.hash(")?;
-                }
-
-                self.out.indent();
-                self.out.indent();
-                self.out.indent();
-
-                for field in fields {
-                    writeln!(
-                        self.out,
-                        "{},",
-                        self.quote_field(&field.name.to_mixed_case())
-                    )?;
-                }
-
-                self.out.unindent();
-
-                if use_hash_all {
-                    writeln!(self.out, "]);")?;
-                } else {
-                    writeln!(self.out, ");")?;
-                }
-
-                self.out.unindent();
-                self.out.unindent();
             }
+
+            self.out.unindent();
+
+            if use_hash_all {
+                writeln!(self.out, "]);")?;
+            } else {
+                writeln!(self.out, ");")?;
+            }
+
+            self.out.unindent();
+            self.out.unindent();
         }
 
         // Generate a toString implementation in each class

--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -486,7 +486,7 @@ if (tag) {{
                     self.out,
                     r#"
 final length = deserializer.deserializeLength();
-return List.generate(length, (_i) => {0});
+return List.generate(length, (_) => {0});
 "#,
                     self.quote_deserialize(format)
                 )?;

--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -1004,7 +1004,7 @@ switch (index) {{"#,
             }
             writeln!(
                 self.out,
-                "default: throw Exception(\"Unknown variant index for {}: \" + index.toString());",
+                "default: throw Exception('Unknown variant index for {}: ' + index.toString());",
                 self.quote_qualified_name(name),
             )?;
             self.out.unindent();
@@ -1090,7 +1090,7 @@ switch (index) {{"#,
             }
             writeln!(
                 self.out,
-                "default: throw Exception(\"Unknown variant index for {}: \" + index.toString());",
+                "default: throw Exception('Unknown variant index for {}: ' + index.toString());",
                 self.quote_qualified_name(name),
             )?;
             self.out.unindent();

--- a/serde-generate/src/dart.rs
+++ b/serde-generate/src/dart.rs
@@ -175,7 +175,7 @@ where
     fn output_preamble(&mut self) -> Result<()> {
         writeln!(
             self.out,
-            "part of '{}.dart';",
+            "// ignore_for_file: type=lint, type=warning\npart of '{}.dart';",
             self.generator.config.module_name
         )?;
 


### PR DESCRIPTION
## Summary

This PR makes Dart linter happy by adapting to its rules.

While applying `serde-reflection` to [`rinf`](https://github.com/cunarist/rinf), warnings were generated by the Dart language server. This PR addresses all of them.

Below are some of the warnings that were shown in VScode.

![image](https://github.com/user-attachments/assets/ec926852-2a1d-4277-9e5c-c65bd7139e4d)
![image](https://github.com/user-attachments/assets/3510dc58-c828-4687-91ba-e267602e30f8)


## Test Plan

The runtime behavior shouldn't change. If the CI works, then everything would be fine.
