### PR TITLE
Support following case convention for Swift.

### DIFF
--- a/serde-generate/src/config.rs
+++ b/serde-generate/src/config.rs
@@ -14,6 +14,7 @@ pub struct CodeGeneratorConfig {
     pub custom_code: CustomCode,
     pub c_style_enums: bool,
     pub package_manifest: bool,
+    pub case_convention_matters: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
@@ -69,6 +70,7 @@ impl CodeGeneratorConfig {
             custom_code: BTreeMap::new(),
             c_style_enums: false,
             package_manifest: true,
+            case_convention_matters: false,
         }
     }
 
@@ -123,6 +125,12 @@ impl CodeGeneratorConfig {
     /// Generate a package manifest file for the target language.
     pub fn with_package_manifest(mut self, package_manifest: bool) -> Self {
         self.package_manifest = package_manifest;
+        self
+    }
+
+    /// Does case convention matters.
+    pub fn with_case_convention_matters(mut self, matters: bool) -> Self {
+        self.case_convention_matters = matters;
         self
     }
 }

--- a/serde-generate/src/config.rs
+++ b/serde-generate/src/config.rs
@@ -14,7 +14,6 @@ pub struct CodeGeneratorConfig {
     pub custom_code: CustomCode,
     pub c_style_enums: bool,
     pub package_manifest: bool,
-    pub case_convention_matters: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
@@ -70,7 +69,6 @@ impl CodeGeneratorConfig {
             custom_code: BTreeMap::new(),
             c_style_enums: false,
             package_manifest: true,
-            case_convention_matters: false,
         }
     }
 
@@ -125,12 +123,6 @@ impl CodeGeneratorConfig {
     /// Generate a package manifest file for the target language.
     pub fn with_package_manifest(mut self, package_manifest: bool) -> Self {
         self.package_manifest = package_manifest;
-        self
-    }
-
-    /// Does case convention matters.
-    pub fn with_case_convention_matters(mut self, matters: bool) -> Self {
-        self.case_convention_matters = matters;
         self
     }
 }

--- a/serde-generate/src/swift.rs
+++ b/serde-generate/src/swift.rs
@@ -91,23 +91,6 @@ impl<'a> CodeGenerator<'a> {
 
         Ok(())
     }
-
-    /// Whether case convention matters or not.
-    ///
-    /// If `true`, transform following the [Swift case conventions](https://www.swift.org/documentation/api-design-guidelines/#conventions).
-    ///   - Names of types and protocols are `UpperCamelCase`. Everything else is `lowerCamelCase`.
-    ///   
-    /// If `false`, Otherwise, return the origin name.
-    ///
-    /// Notes: Since conventions of types and protocols are the same, we just need to transform
-    /// everything else.
-    fn transform_case_convention_if_need(&self, name: String) -> String {
-        if self.config.case_convention_matters {
-            name.to_mixed_case()
-        } else {
-            name
-        }
-    }
 }
 
 impl<'a, T> SwiftEmitter<'a, T>
@@ -486,9 +469,7 @@ return obj
     fn output_variant(&mut self, name: &str, variant: &VariantFormat) -> Result<()> {
         use VariantFormat::*;
         self.output_comment(name)?;
-        let name = self
-            .generator
-            .transform_case_convention_if_need(common::lowercase_first_letter(name));
+        let name = common::lowercase_first_letter(name).to_mixed_case();
         match variant {
             Unit => {
                 writeln!(self.out, "case {}", name)?;
@@ -703,9 +684,8 @@ public static func {1}Deserialize(input: [UInt8]) throws -> {0} {{
             writeln!(self.out, "switch self {{")?;
             for (index, variant) in variants {
                 let fields = Self::variant_fields(&variant.value);
-                let formatted_variant_name = self.generator.transform_case_convention_if_need(
-                    common::lowercase_first_letter(&variant.name),
-                );
+                let formatted_variant_name =
+                    common::lowercase_first_letter(&variant.name).to_mixed_case();
                 if fields.is_empty() {
                     writeln!(self.out, "case .{}:", formatted_variant_name)?;
                 } else {
@@ -762,9 +742,8 @@ switch index {{"#,
             for (index, variant) in variants {
                 writeln!(self.out, "case {}:", index)?;
                 self.out.indent();
-                let formatted_variant_name = self.generator.transform_case_convention_if_need(
-                    common::lowercase_first_letter(&variant.name),
-                );
+                let formatted_variant_name =
+                    common::lowercase_first_letter(&variant.name).to_mixed_case();
                 let fields = Self::variant_fields(&variant.value);
                 if fields.is_empty() {
                     writeln!(self.out, "try deserializer.decrease_container_depth()")?;
@@ -841,9 +820,7 @@ switch index {{"#,
             Struct(fields) => fields
                 .iter()
                 .map(|f| Named {
-                    name: self
-                        .generator
-                        .transform_case_convention_if_need(f.name.clone()),
+                    name: f.name.to_mixed_case(),
                     value: f.value.clone(),
                 })
                 .collect(),

--- a/serde-generate/src/swift.rs
+++ b/serde-generate/src/swift.rs
@@ -8,7 +8,7 @@ use crate::{
     indent::{IndentConfig, IndentedWriter},
     CodeGeneratorConfig, Encoding,
 };
-use heck::CamelCase;
+use heck::{CamelCase, MixedCase};
 use include_dir::include_dir as include_directory;
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
 use std::{
@@ -90,6 +90,23 @@ impl<'a> CodeGenerator<'a> {
         }
 
         Ok(())
+    }
+
+    /// Whether case convention matters or not.
+    ///
+    /// If `true`, transform following the [Swift case conventions](https://www.swift.org/documentation/api-design-guidelines/#conventions).
+    ///   - Names of types and protocols are `UpperCamelCase`. Everything else is `lowerCamelCase`.
+    ///   
+    /// If `false`, Otherwise, return the origin name.
+    ///
+    /// Notes: Since conventions of types and protocols are the same, we just need to transform
+    /// everything else.
+    fn transform_case_convention_if_need(&self, name: String) -> String {
+        if self.config.case_convention_matters {
+            name.to_mixed_case()
+        } else {
+            name
+        }
     }
 }
 
@@ -469,7 +486,9 @@ return obj
     fn output_variant(&mut self, name: &str, variant: &VariantFormat) -> Result<()> {
         use VariantFormat::*;
         self.output_comment(name)?;
-        let name = common::lowercase_first_letter(name);
+        let name = self
+            .generator
+            .transform_case_convention_if_need(common::lowercase_first_letter(name));
         match variant {
             Unit => {
                 writeln!(self.out, "case {}", name)?;
@@ -684,7 +703,9 @@ public static func {1}Deserialize(input: [UInt8]) throws -> {0} {{
             writeln!(self.out, "switch self {{")?;
             for (index, variant) in variants {
                 let fields = Self::variant_fields(&variant.value);
-                let formatted_variant_name = common::lowercase_first_letter(&variant.name);
+                let formatted_variant_name = self.generator.transform_case_convention_if_need(
+                    common::lowercase_first_letter(&variant.name),
+                );
                 if fields.is_empty() {
                     writeln!(self.out, "case .{}:", formatted_variant_name)?;
                 } else {
@@ -741,7 +762,9 @@ switch index {{"#,
             for (index, variant) in variants {
                 writeln!(self.out, "case {}:", index)?;
                 self.out.indent();
-                let formatted_variant_name = common::lowercase_first_letter(&variant.name);
+                let formatted_variant_name = self.generator.transform_case_convention_if_need(
+                    common::lowercase_first_letter(&variant.name),
+                );
                 let fields = Self::variant_fields(&variant.value);
                 if fields.is_empty() {
                     writeln!(self.out, "try deserializer.decrease_container_depth()")?;
@@ -818,7 +841,9 @@ switch index {{"#,
             Struct(fields) => fields
                 .iter()
                 .map(|f| Named {
-                    name: f.name.clone(),
+                    name: self
+                        .generator
+                        .transform_case_convention_if_need(f.name.clone()),
                     value: f.value.clone(),
                 })
                 .collect(),

--- a/serde-generate/tests/swift_generation.rs
+++ b/serde-generate/tests/swift_generation.rs
@@ -197,7 +197,6 @@ fn test_that_swift_code_compiles_with_case_convention_matters() {
     // Case convention were correctly followed.
     let content = std::fs::read_to_string(source_path).unwrap();
 
-    println!("content={}", content);
     // Enum variants are lowerCamelCase.
     assert!(content.contains(r#"case primitiveTypes"#));
     assert!(!content.contains(r#"case PrimitiveTypes"#));

--- a/serde-generate/tests/swift_generation.rs
+++ b/serde-generate/tests/swift_generation.rs
@@ -188,3 +188,10 @@ fn test_that_swift_code_compiles_with_custom_code() {
     let content = std::fs::read_to_string(source_path).unwrap();
     assert!(content.contains("// custom1"));
 }
+
+#[test]
+fn test_that_swift_code_compiles_with_case_convention_matters() {
+    let config = CodeGeneratorConfig::new("Testing".to_string()).with_case_convention_matters(true);
+
+    test_that_swift_code_compiles_with_config(&config);
+}

--- a/serde-generate/tests/swift_generation.rs
+++ b/serde-generate/tests/swift_generation.rs
@@ -191,7 +191,18 @@ fn test_that_swift_code_compiles_with_custom_code() {
 
 #[test]
 fn test_that_swift_code_compiles_with_case_convention_matters() {
-    let config = CodeGeneratorConfig::new("Testing".to_string()).with_case_convention_matters(true);
+    let config = CodeGeneratorConfig::new("Testing".to_string());
 
-    test_that_swift_code_compiles_with_config(&config);
+    let (_dir, source_path) = test_that_swift_code_compiles_with_config(&config);
+    // Case convention were correctly followed.
+    let content = std::fs::read_to_string(source_path).unwrap();
+
+    println!("content={}", content);
+    // Enum variants are lowerCamelCase.
+    assert!(content.contains(r#"case primitiveTypes"#));
+    assert!(!content.contains(r#"case PrimitiveTypes"#));
+    assert!(!content.contains(r#"case primitive_ypes"#));
+    // Field names are lowerCamelCase.
+    assert!(content.contains(r#"@Indirect public var fBool: Bool"#));
+    assert!(!content.contains(r#"@Indirect public var f_bool: Bool"#));
 }

--- a/serde-generate/tests/swift_generation.rs
+++ b/serde-generate/tests/swift_generation.rs
@@ -190,18 +190,18 @@ fn test_that_swift_code_compiles_with_custom_code() {
 }
 
 #[test]
-fn test_that_swift_code_compiles_with_case_convention_matters() {
+fn test_that_swift_code_follow_case_convention() {
     let config = CodeGeneratorConfig::new("Testing".to_string());
 
     let (_dir, source_path) = test_that_swift_code_compiles_with_config(&config);
     // Case convention were correctly followed.
     let content = std::fs::read_to_string(source_path).unwrap();
 
-    // Enum variants are lowerCamelCase.
+    // Enum variants are `lowerCamelCase`.
     assert!(content.contains(r#"case primitiveTypes"#));
     assert!(!content.contains(r#"case PrimitiveTypes"#));
     assert!(!content.contains(r#"case primitive_ypes"#));
-    // Field names are lowerCamelCase.
+    // Field names are `lowerCamelCase`.
     assert!(content.contains(r#"@Indirect public var fBool: Bool"#));
     assert!(!content.contains(r#"@Indirect public var f_bool: Bool"#));
 }


### PR DESCRIPTION
## Summary

 * Introduces a new configuration option to handle case conventions in the `serde-generate` library and updates the Swift code generation to respect this option. The main changes include the addition of a new field to the `CodeGeneratorConfig` struct, updates to the Swift code generator to transform names based on this new configuration, and the addition of a new test case to verify the functionality. Similar to #11 , with more scope and keep flexibility, non-breaking changes 🙏.

## Test Plan

  * Added a new test case `test_that_swift_code_compiles_with_case_convention_matters` to ensure Swift code compiles correctly when `case_convention_matters` is enabled.
