### PR TITLE
Make `Serializer` and `Deserializer` `pub`, access `incomplete_enum` mechanism

### DIFF
--- a/serde-reflection/src/de.rs
+++ b/serde-reflection/src/de.rs
@@ -27,11 +27,7 @@ pub struct Deserializer<'de, 'a> {
 }
 
 impl<'de, 'a> Deserializer<'de, 'a> {
-    pub fn new(
-        tracer: &'a mut Tracer,
-        samples: &'de Samples,
-        format: &'a mut Format,
-    ) -> Self {
+    pub fn new(tracer: &'a mut Tracer, samples: &'de Samples, format: &'a mut Format) -> Self {
         Deserializer {
             tracer,
             samples,

--- a/serde-reflection/src/de.rs
+++ b/serde-reflection/src/de.rs
@@ -20,14 +20,14 @@ use std::collections::btree_map::{BTreeMap, Entry};
 ///   `&'a mut` references used to return tracing results.
 /// * The lifetime 'de is fixed and the `&'de` reference meant to let us
 ///   borrow values from previous serialization runs.
-pub(crate) struct Deserializer<'de, 'a> {
+pub struct Deserializer<'de, 'a> {
     tracer: &'a mut Tracer,
     samples: &'de Samples,
     format: &'a mut Format,
 }
 
 impl<'de, 'a> Deserializer<'de, 'a> {
-    pub(crate) fn new(
+    pub fn new(
         tracer: &'a mut Tracer,
         samples: &'de Samples,
         format: &'a mut Format,

--- a/serde-reflection/src/lib.rs
+++ b/serde-reflection/src/lib.rs
@@ -365,3 +365,4 @@ pub use error::{Error, Result};
 pub use format::{ContainerFormat, Format, FormatHolder, Named, Variable, VariantFormat};
 pub use trace::{Registry, Samples, Tracer, TracerConfig};
 pub use value::Value;
+pub use ser::Serializer;

--- a/serde-reflection/src/lib.rs
+++ b/serde-reflection/src/lib.rs
@@ -361,9 +361,9 @@ mod ser;
 mod trace;
 mod value;
 
+pub use de::Deserializer;
 pub use error::{Error, Result};
 pub use format::{ContainerFormat, Format, FormatHolder, Named, Variable, VariantFormat};
+pub use ser::Serializer;
 pub use trace::{Registry, Samples, Tracer, TracerConfig};
 pub use value::Value;
-pub use ser::Serializer;
-pub use de::Deserializer;

--- a/serde-reflection/src/lib.rs
+++ b/serde-reflection/src/lib.rs
@@ -366,3 +366,4 @@ pub use format::{ContainerFormat, Format, FormatHolder, Named, Variable, Variant
 pub use trace::{Registry, Samples, Tracer, TracerConfig};
 pub use value::Value;
 pub use ser::Serializer;
+pub use de::Deserializer;

--- a/serde-reflection/src/ser.rs
+++ b/serde-reflection/src/ser.rs
@@ -12,13 +12,13 @@ use serde::{ser, Serialize};
 /// Serialize a single value.
 /// The lifetime 'a is set by the serialization call site and the `&'a mut`
 /// references used to return tracing results and serialization samples.
-pub(crate) struct Serializer<'a> {
+pub struct Serializer<'a> {
     tracer: &'a mut Tracer,
     samples: &'a mut Samples,
 }
 
 impl<'a> Serializer<'a> {
-    pub(crate) fn new(tracer: &'a mut Tracer, samples: &'a mut Samples) -> Self {
+    pub fn new(tracer: &'a mut Tracer, samples: &'a mut Samples) -> Self {
         Self { tracer, samples }
     }
 }

--- a/serde-reflection/src/trace.rs
+++ b/serde-reflection/src/trace.rs
@@ -30,14 +30,14 @@ pub struct Tracer {
 
     /// Enums that have detected to be yet incomplete (i.e. missing variants)
     /// while tracing deserialization.
-    pub(crate) incomplete_enums: BTreeMap<String, EnumProgress>,
+    pub incomplete_enums: BTreeMap<String, EnumProgress>,
 
     /// Discriminant associated with each variant of each enum.
     pub(crate) discriminants: BTreeMap<(TypeId, VariantId<'static>), Discriminant>,
 }
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) enum EnumProgress {
+pub enum EnumProgress {
     /// There are variant names that have not yet been traced.
     NamedVariantsRemaining,
     /// There are variant numbers that have not yet been traced.


### PR DESCRIPTION
## Summary

[`miniconf`](https://github.com/quartiq/miniconf) is a library we use to access (get/set over serial, mqtt, store in flash) settings on embedded devices. It is a `serde`-based hierarchical heterogeneous key-value access mechanism.
We'd like to generate a schema for the settings trees and found `serde-reflection` very useful for this (thanks!).

We implement the `trace_value`/`trace_type` functionality in `Tracer` using our intermediate `miniconf::TreeSerialize`/`TreeDeserialize` traits. See below for what that looks like.

For `trace_value` and `trace_type_once` we would like `Serializer` and `Deserializer` to be `pub`. Happy to split that out of this PR if it's uncontroversial.

For `trace_type` we also need a way to perform the removal of the top level enum from `incomplete_enums` before tracing again (see `trace_type`). I feel like making it fully `pub` permits breaking implicit guarantees so I'm looking into other ways of exposing just that reset-before-trace. Input and guidance welcome.

## Test Plan

```bash
git clone https://github.com/quartiq/miniconf.git
cd miniconf
# note that miniconf is using this serde-reflection branch in miniconf/Cargo.toml
cargo run -p miniconf --example trace --all-features
```

Code: https://github.com/quartiq/miniconf/blob/b79f73d1858454eb384f6b5401d206d2f59dbc95/miniconf/examples/trace.rs#L132-L170

```rust
/// Trace a leaf value
pub fn trace_value<T: TreeSerialize, K: Keys>(
    tracer: &mut Tracer,
    samples: &mut Samples,
    keys: K,
    value: &T,
) -> Result<(Format, Value), Error<serde_reflection::Error>> {
    value.serialize_by_key(keys, Serializer::new(tracer, samples))
}


/// Trace a leaf type once
pub fn trace_type_once<'de, T: TreeDeserialize<'de>, K: Keys>(
    tracer: &mut Tracer,
    samples: &'de Samples,
    keys: K,
) -> Result<Format, Error<serde_reflection::Error>> {
    let mut format = Format::unknown();
    T::probe_by_key(keys, Deserializer::new(tracer, samples, &mut format))?;
    format.reduce();
    Ok(format)
}


/// Trace a leaf type until complete
pub fn trace_type<'de, T: TreeDeserialize<'de>, K: Keys + Clone>(
    tracer: &mut Tracer,
    samples: &'de Samples,
    keys: K,
) -> Result<Format, Error<serde_reflection::Error>> {
    loop {
        let format = trace_type_once::<T, _>(tracer, samples, keys.clone())?;
        if let Format::TypeName(name) = &format {
            if tracer.incomplete_enums.remove(name).is_some() {
                // Restart the analysis to find more variants.
                continue;
            }
        }
        return Ok(format);
    }
}
```

