### PR TITLE
Fix dart bytes hashcode

### DIFF
--- a/serde-generate/runtime/dart/serde/bytes.dart
+++ b/serde-generate/runtime/dart/serde/bytes.dart
@@ -20,5 +20,5 @@ class Bytes {
   }
 
   @override
-  int get hashCode => content.hashCode;
+  int get hashCode => Object.hashAll(content);
 }

--- a/serde-generate/runtime/dart/test/serde_test.dart
+++ b/serde-generate/runtime/dart/test/serde_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+import 'dart:typed_data';
+
 import 'package:test/test.dart';
 
 import '../serde/serde.dart';
@@ -27,5 +29,17 @@ void main() {
     expect(Int128.parse('170').toString(), '170');
     expect(Int128.parse('170141183460469231731687303715884105727').toString(),
         '170141183460469231731687303715884105727');
+  });
+
+  test('Bytes', () {
+    final a = Bytes(Uint8List.fromList([0]));
+    final b = Bytes(Uint8List.fromList([0]));
+    final c = Bytes(Uint8List.fromList([1]));
+
+    expect(a, b, reason: 'a == b');
+    expect(a.hashCode, b.hashCode, reason: 'a and b have same hashCode');
+
+    expect(a, isNot(c), reason: 'a != c');
+    expect(a.hashCode, isNot(c.hashCode), reason: 'a and c have different hashCode');
   });
 }


### PR DESCRIPTION
## Summary

Discovered that the [`hashCode` implementation for `Bytes` in the dart runtime](https://github.com/zefchain/serde-reflection/blob/364ff774dcd2596fe8d9ce88e474bb4f57ee4141/serde-generate/runtime/dart/serde/bytes.dart#L23) is incorrect. Instead of just returning the `hashCode` of `content`, it needs to returned the combined hash of each item in `content`. As is, `hashCode` returns different values for `Bytes` instances that are `==`.

## Test Plan

Added new unit test for `Bytes` that checks equality and hashCode.