### PR TITLE
Fix parameter naming in generated code to resolve linter warnings

### DIFF
--- a/serde-generate/runtime/dart/bincode/bincode_serializer.dart
+++ b/serde-generate/runtime/dart/bincode/bincode_serializer.dart
@@ -10,13 +10,13 @@ class BincodeSerializer extends BinarySerializer {
         );
 
   @override
-  void serializeLength(int value) {
-    serializeUint64(Uint64(BigInt.from(value)));
+  void serializeLength(int len) {
+    serializeUint64(Uint64(BigInt.from(len)));
   }
 
   @override
-  void serializeVariantIndex(int value) {
-    serializeUint32(value);
+  void serializeVariantIndex(int index) {
+    serializeUint32(index);
   }
 
   @override


### PR DESCRIPTION
## Problem

The `rinf` package generates code that copied from this repository, but the generated code consistently produces linter warnings that make repository maintenance painful. Every time `rinf` executes code generation, it outputs code that triggers the following warnings:

```
The parameter name 'value' doesn't match the name 'len' in the overridden method.
Try changing the name to 'len'.dart[avoid_renaming_method_parameters]
```

```
The parameter name 'value' doesn't match the name 'index' in the overridden method.
Try changing the name to 'index'.dart[avoid_renaming_method_parameters]
```

## Impact

- **Developer Experience**: These warnings appear repeatedly during development, creating noise in the linter output
- **Maintenance Burden**: Every code generation cycle reintroduces these warnings, making it difficult to maintain clean code standards

## Changes

- Updated parameter names from `value` to `len` in methods where the overridden method expects `len`
- Updated parameter names from `value` to `index` in methods where the overridden method expects `index`
- Ensured consistency between method signatures and their overridden counterparts

Related to: https://github.com/cunarist/rinf/issues/632#event-18957574703
Maintainer: @temeddix