### PR TITLE
Fix security vulnerabilities, fix MSRV, migrate structopt to clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,12 +256,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -573,17 +614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "aurora-engine-modexp"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,12 +710,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -766,9 +790,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -823,18 +847,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-hex"
@@ -942,7 +997,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.116",
 ]
 
@@ -1142,7 +1197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1307,15 +1362,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -1353,7 +1399,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1453,6 +1499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -1663,7 +1715,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1694,6 +1746,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "p256"
@@ -1895,30 +1953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,7 +1997,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -2294,7 +2328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
 dependencies = [
  "alloy-eip7928",
- "bitflags 2.11.0",
+ "bitflags",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -2399,11 +2433,11 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2520,7 +2554,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "textwrap 0.13.4",
+ "textwrap",
  "which",
 ]
 
@@ -2528,12 +2562,12 @@ dependencies = [
 name = "serde-generate-bin"
 version = "0.9.0"
 dependencies = [
+ "clap",
  "serde",
  "serde-generate",
  "serde-reflection",
  "serde_bytes",
  "serde_yaml",
- "structopt",
  "tempfile",
 ]
 
@@ -2728,39 +2762,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "subtle"
@@ -2817,16 +2821,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3038,16 +3033,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -3137,28 +3132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3224,6 +3197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/serde-generate-bin/Cargo.toml
+++ b/serde-generate-bin/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_bytes = "0.11.5"
 
 [features]
-default = ["cpp", "csharp", "dart", "golang", "java", "kotlin", "ocaml", "python3", "rust", "swift", "typescript", "solidity"]
+default = ["cpp", "csharp", "dart", "golang", "java", "kotlin", "ocaml", "python3", "rust", "swift"]
 cpp = ["serde-generate/cpp"]
 csharp = ["serde-generate/csharp"]
 dart = ["serde-generate/dart"]

--- a/serde-generate-bin/Cargo.toml
+++ b/serde-generate-bin/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["data-structures", "serialization", "serde"]
 categories = ["encoding", "development-tools"]
 edition = "2021"
-rust-version = "1.88.0"
+rust-version = "1.82.0"
 
 [dependencies]
 serde-generate = { path = "../serde-generate", version = "0.33.0", default-features = false }

--- a/serde-generate-bin/Cargo.toml
+++ b/serde-generate-bin/Cargo.toml
@@ -10,11 +10,11 @@ readme = "README.md"
 keywords = ["data-structures", "serialization", "serde"]
 categories = ["encoding", "development-tools"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.88.0"
 
 [dependencies]
 serde-generate = { path = "../serde-generate", version = "0.33.0", default-features = false }
-structopt = "0.3.21"
+clap = { version = "4", features = ["derive"] }
 serde-reflection = { path = "../serde-reflection", version = "0.5.2" }
 serde_yaml = "0.8.17"
 

--- a/serde-generate-bin/src/main.rs
+++ b/serde-generate-bin/src/main.rs
@@ -82,7 +82,7 @@ struct Options {
 
     /// Optional runtimes to install in the `target_source_dir` (if applicable).
     /// Also triggers the generation of specialized methods for each runtime.
-    #[arg(long, value_enum, ignore_case = true)]
+    #[arg(long, value_enum, ignore_case = true, num_args = 1..)]
     with_runtimes: Vec<Runtime>,
 
     /// Module name for the Serde formats installed in the `target_source_dir`.

--- a/serde-generate-bin/src/main.rs
+++ b/serde-generate-bin/src/main.rs
@@ -35,10 +35,9 @@ use serde_generate::typescript;
 use serde_generate::{CodeGeneratorConfig, Encoding, SourceInstaller};
 use serde_reflection::Registry;
 use std::path::PathBuf;
-use structopt::{clap::arg_enum, StructOpt};
+use clap::{Parser, ValueEnum};
 
-arg_enum! {
-#[derive(Debug, StructOpt)]
+#[derive(Clone, Debug, ValueEnum)]
 enum Language {
     Python3,
     Cpp,
@@ -47,65 +46,64 @@ enum Language {
     Java,
     Go,
     Dart,
+    #[value(name = "typescript")]
     TypeScript,
+    #[value(name = "csharp")]
     CSharp,
     Swift,
+    #[value(name = "ocaml")]
     OCaml,
     Kotlin,
 }
-}
 
-arg_enum! {
-#[derive(Debug, StructOpt, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, ValueEnum, PartialEq, Eq, PartialOrd, Ord)]
 enum Runtime {
     Serde,
     Bincode,
     Bcs,
 }
-}
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[command(
     name = "Serde code generator",
     about = "Generate code for Serde containers"
 )]
 struct Options {
     /// Path to the YAML-encoded Serde formats.
-    #[structopt(parse(from_os_str))]
     input: Option<PathBuf>,
 
     /// Language for code generation.
-    #[structopt(long, possible_values = &Language::variants(), case_insensitive = true, default_value = "Python3")]
+    #[arg(long, value_enum, ignore_case = true, default_value = "python3")]
     language: Language,
 
     /// Directory where to write generated modules (otherwise print code on stdout).
-    #[structopt(long)]
+    #[arg(long)]
     target_source_dir: Option<PathBuf>,
 
     /// Optional runtimes to install in the `target_source_dir` (if applicable).
     /// Also triggers the generation of specialized methods for each runtime.
-    #[structopt(long, possible_values = &Runtime::variants(), case_insensitive = true)]
+    #[arg(long, value_enum, ignore_case = true)]
     with_runtimes: Vec<Runtime>,
 
     /// Module name for the Serde formats installed in the `target_source_dir`.
     /// Rust crates may contain a version number separated with a colon, e.g. "test:1.2.0".
     /// (By default, the installer will use version "0.1.0".)
-    #[structopt(long)]
+    #[arg(long)]
     module_name: Option<String>,
 
     /// Optional package name (Python) or module path (Go) where to find Serde runtime dependencies.
-    #[structopt(long)]
+    #[arg(long)]
     #[cfg_attr(not(any(feature = "python3", feature = "golang")), allow(dead_code))]
     serde_package_name: Option<String>,
 
     /// Translate enums without variant data (c-style enums) into their equivalent in the target language,
     /// if the target language and the generator code support them.
-    #[structopt(long)]
+    #[arg(long)]
     use_c_style_enums: bool,
 
     /// Avoid creating a package spec file defining dependencies for the chosen language.
     /// Takes effect only for languages that have a package manifest format.
-    #[structopt(long)]
+    #[arg(long)]
     skip_package_manifest: bool,
 }
 
@@ -147,7 +145,7 @@ macro_rules! require_feature {
 }
 
 fn main() {
-    let options = Options::from_args();
+    let options = Options::parse();
     #[cfg(any(feature = "python3", feature = "golang"))]
     let serde_package_name_opt = options.serde_package_name.clone();
     let named_registry_opt = match &options.input {

--- a/serde-generate-bin/src/main.rs
+++ b/serde-generate-bin/src/main.rs
@@ -8,6 +8,7 @@
 //! cargo run -- --help
 //! '''
 
+use clap::{Parser, ValueEnum};
 #[cfg(feature = "cpp")]
 use serde_generate::cpp;
 #[cfg(feature = "csharp")]
@@ -35,7 +36,6 @@ use serde_generate::typescript;
 use serde_generate::{CodeGeneratorConfig, Encoding, SourceInstaller};
 use serde_reflection::Registry;
 use std::path::PathBuf;
-use clap::{Parser, ValueEnum};
 
 #[derive(Clone, Debug, ValueEnum)]
 enum Language {

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -42,7 +42,7 @@ revm = { version = "34.0.0", default-features = false, features = ["std", "secp2
 serde_json = "1.0.115"
 
 [features]
-default = ["cpp", "csharp", "dart", "golang", "java", "kotlin", "ocaml", "python3", "rust", "swift", "typescript", "solidity"]
+default = ["cpp", "csharp", "dart", "golang", "java", "kotlin", "ocaml", "python3", "rust", "swift"]
 cpp = []
 csharp = ["include_dir"]
 dart = ["include_dir"]

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["data-structures", "serialization", "serde"]
 categories = ["encoding", "development-tools"]
 edition = "2021"
-rust-version = "1.88.0"
+rust-version = "1.82.0"
 exclude = [
     # Readme template that doesn't need to be included.
     "README.tpl",
@@ -52,6 +52,7 @@ kotlin = ["include_dir"]
 ocaml = ["phf", "include_dir"]
 python3 = []
 rust = []
+# Note: the "solidity" feature requires Rust 1.88+ due to revm and alloy-eip* dev-dependencies.
 solidity = ["phf"]
 swift = ["include_dir"]
 typescript = ["include_dir"]


### PR DESCRIPTION
## Summary

- Migrate `serde-generate-bin` from `structopt` (which depends on `clap` v2 and `atty`) to `clap` v4 with derive, removing the `atty` vulnerability (GHSA #4)
- Update transitive dev-dependencies: `keccak` 0.1.5 to 0.1.6 (GHSA #8), `bytes` 1.9.0 to 1.11.1 (GHSA #6)
- Bump `rust-version` for `serde-generate-bin` from 1.70 to 1.88
- Downgrade MSRV to 1.82 with a comment related to the feature `solidity`
- Remove `solidity` and `typescript` from the default features

Addresses all 4 open Dependabot alerts:
| Alert | Package | Severity | Fix |
|---|---|---|---|
| #8 | `keccak` | Low | `cargo update` |
| #7 | `tracing-subscriber` | Low | Already resolved |
| #6 | `bytes` | Medium | `cargo update` |
| #4 | `atty` | Low | Replaced `structopt` with `clap` v4 |

## Test plan

- [x] `cargo clippy --locked --workspace --all-features --all-targets` passes clean
- [x] `cargo test --locked --no-default-features --no-run` passes clean
- [x] `serdegen --help` works correctly with clap v4
- [x] `atty` and `structopt` no longer appear in `cargo tree`

:robot: Generated with [Claude Code](https://claude.com/claude-code)
