### PR TITLE
solidity: use shifts instead of multiply in LEB128 length decoder

### DIFF
--- a/serde-generate/src/solidity.rs
+++ b/serde-generate/src/solidity.rs
@@ -1549,13 +1549,13 @@ function bcs_deserialize_offset_len(uint256 pos, bytes memory input)
     while (true) {{
         if (uint8(input[pos + idx]) < 128) {{
             uint256 result = 0;
-            uint256 power = 1;
+            uint256 shift = 0;
             for (uint256 u=0; u<idx; u++) {{
                 uint8 val = uint8(input[pos + u]) - 128;
-                result += power * uint256(val);
-                power *= 128;
+                result |= uint256(val) << shift;
+                shift += 7;
             }}
-            result += power * uint8(input[pos + idx]);
+            result |= uint256(uint8(input[pos + idx])) << shift;
             return (pos + idx + 1, result);
         }}
         idx += 1;


### PR DESCRIPTION
## Summary

`* 128` and `* val` on uint256 each cost 5 gas where `<< 7` costs 3. The Yul optimizer probably already folds `* 128` to `<< 7`, but rewriting the inner loop in terms of shift/OR makes the intent explicit and removes the question.

## Test Plan

Functionally equivalent: existing multi-byte length round-trip coverage (vec i64 of length 140) exercises this path.
