### PR TITLE
solidity: mark generated assembly block as memory-safe

### DIFF
--- a/serde-generate/src/solidity.rs
+++ b/serde-generate/src/solidity.rs
@@ -1107,7 +1107,7 @@ function bcs_deserialize_offset_{name}(uint256 pos, bytes memory input)
     returns (uint256, {name})
 {{
     {name} dest;
-    assembly {{
+    assembly ("memory-safe") {{
         dest := mload(add(add(input, 0x20), pos))
     }}
     return (pos + {size}, dest);


### PR DESCRIPTION
## Summary

The `BytesN` codegen path emits a one-line `mload` inside an `assembly` block to read a fixed-size byte array out of a `bytes memory` argument. The block reads memory only, does not touch the free memory pointer (`0x40`) or the zero slot (`0x60`), and never writes outside the function's allocated memory — so it satisfies the Solidity memory-safety contract documented at
https://docs.soliditylang.org/en/latest/assembly.html#memory-safety.

Annotating it accordingly lets the IR optimizer spill registers freely. Without the annotation, callers that inline the deserializer tree can hit "stack too deep" once the input contract grows; we observed this in https://github.com/linera-io/linera-protocol/pull/6294.

This is the only `assembly { ... }` emission in the Solidity backend.

## Test Plan

https://github.com/linera-io/linera-protocol/pull/6294 works with this branch of `serde-refliection`.
