### PR TITLE
fix(solidity): emit bool primitive helpers for Option types

### DIFF
--- a/serde-generate/src/solidity.rs
+++ b/serde-generate/src/solidity.rs
@@ -1326,6 +1326,15 @@ impl SolRegistry {
             SolFormat::TypeName(_) => {
                 // Typename entries do not need to be inserted.
             }
+            SolFormat::Option(_) => {
+                // The `opt_*` (de)serializer reads a one-byte bool tag, so emitting it requires the
+                // `bool` primitive helpers — even when no registry field is a literal `bool` (the
+                // `Option` dependency list already declares `"bool"`). Without this, generated code
+                // calls `bcs_*_bool` that is never defined.
+                self.names
+                    .insert("bool".to_string(), SolFormat::Primitive(Primitive::Bool));
+                self.names.insert(key_name, sol_format);
+            }
             _ => {
                 self.names.insert(key_name, sol_format);
             }

--- a/serde-generate/tests/solidity_generation.rs
+++ b/serde-generate/tests/solidity_generation.rs
@@ -844,3 +844,32 @@ fn test_rejects_lowercase_container_name() {
     let config = CodeGeneratorConfig::new("Test".into());
     let _ = generate_solidity(&config, &registry);
 }
+
+#[test]
+fn test_option_emits_bool_primitive_without_literal_bool_field() {
+    // An `Option<T>` field makes the generated `opt_*` (de)serializer read a one-byte bool tag, so
+    // the `bool` primitive helpers must be emitted even though no field is a literal `bool`.
+    // Regression: the helpers used to be emitted only when some container had a literal `bool`
+    // field, so a registry like this one produced `bcs_*_bool` calls with no definition.
+    #[derive(Serialize, Deserialize)]
+    struct Inner {
+        x: u64,
+    }
+    #[derive(Serialize, Deserialize)]
+    struct Outer {
+        maybe: Option<Inner>,
+    }
+
+    let registry = get_registry_from_type::<Outer>();
+    let config = CodeGeneratorConfig::new("test".to_string());
+    let code = generate_solidity(&config, &registry);
+
+    assert!(
+        code.contains("function bcs_serialize_bool("),
+        "Option field must emit the bcs_serialize_bool helper:\n{code}"
+    );
+    assert!(
+        code.contains("function bcs_deserialize_offset_bool("),
+        "Option field must emit the bcs_deserialize_offset_bool helper:\n{code}"
+    );
+}


### PR DESCRIPTION
The Solidity backend generates `opt_*` wrappers for `Option<T>` whose (de)serializer reads a one-byte bool tag and therefore calls `bcs_serialize_bool` / `bcs_deserialize_offset_bool`. An `Option`'s dependency list already declares `"bool"` (so it is in the `needed` set), but `SolRegistry::insert` only registered `Primitive(Bool)` in `names` when some container had a *literal* `bool` field.

Result: a registry that uses `Option` fields but has no literal `bool` anywhere generates Solidity that **calls `bcs_*_bool` without ever defining it** — a compile error in the emitted contract. Downstream users currently work around this by tracing a dummy struct that carries a `bool` field solely to anchor the helpers.

Fix: register the `bool` primitive whenever an `Option` is inserted, mirroring the existing `I8 -> also-insert-U8` internal-dependency handling in `insert`. `OptionBool` is unaffected (its inner `bool` already inserts the primitive); enums/seqs/maps use uleb128 tags rather than a bool tag, so `Option` is the only case.

Added a regression test (`test_option_emits_bool_primitive_without_literal_bool_field`) that traces a struct with an `Option<Inner>` field and no literal `bool`, asserting the generated code defines both bool helpers. It fails before the fix, passes after. Full `solidity` test suite (26 tests, incl. the solc-compiling `test_solidity_compilation`) passes; `cargo fmt`/`clippy` clean.